### PR TITLE
match id and href fragment reference for array section. should be #array

### DIFF
--- a/content/index.markdown
+++ b/content/index.markdown
@@ -123,7 +123,7 @@ The `og:audio` tag only has the first 3 properties available
     <meta property="og:audio:type" content="audio/mpeg" />
 
 ---
-## <a id="array" href="#arrays">Arrays</a>
+## <a id="array" href="#array">Arrays</a>
 
 If a tag can have multiple values, just put multiple versions of the same
 `<meta>` tag on your page. The first tag (from top to bottom) is given


### PR DESCRIPTION
The array section id and href did not match. Changed.
