### PR TITLE
Mention Google consumption of Open Graph protocol markup

### DIFF
--- a/content/index.markdown
+++ b/content/index.markdown
@@ -383,7 +383,8 @@ https://www.facebook.com/groups/opengraph/) or on
 http://groups.google.com/group/open-graph-protocol).
 It is currently being consumed by Facebook
 ([see their documentation](
-http://developers.facebook.com/docs/opengraph)) and
+http://developers.facebook.com/docs/opengraph)), Google ([see their documentation](
+https://developers.google.com/+/plugins/+1button/#plus-snippet)), and
 [mixi](
 http://groups.google.com/group/open-graph-protocol/browse_thread/thread/356d722abf70001d/397ec334ca87f122).
 It is being published by IMDb, Microsoft, NHL, Posterous, Rotten Tomatoes,
@@ -397,6 +398,7 @@ tools. Let the Facebook group know if you've built something awesome too!
 
 * [Facebook Object Debugger](http://developers.facebook.com/tools/debug/) -
   Facebook's official parser and debugger
+* [Google Rich Snippets Testing Tool](http://www.google.com/webmasters/tools/richsnippets) - Google Rich Snippets Testing Tool with support for Open Graph protocol in specific verticals and Custom Search Engines.
 * [OpenGraph.in](http://www.opengraph.in/) -
   a service which parses Open Graph protocol markup and outputs HTML and JSON
 * [OpenGraph for Java](http://github.com/callumj/opengraph-java) -


### PR DESCRIPTION
Google uses Open Graph protocol to populate share stories on Google+ and store additional metadata about a page for use by custom search engines and occasionally core search engine depending on rich snippet type.

Link to Google+ developers page mentioning OGP consumption. Link to Google Rich Snippets testing tool to show recognition of OGP properties by the testing tool.
