### PR TITLE
Grammar and typos cleanup

### DIFF
--- a/content/index.markdown
+++ b/content/index.markdown
@@ -367,7 +367,7 @@ The following types are used when defining attributes in Open Graph protocol.
 
 <tr>
   <td><a name="url" href="#url">URL</td>
-  <td>A sequence of UTF-8 characters that identify a Internet resource.
+  <td>A sequence of UTF-8 characters that identify an Internet resource.
   <td>All valid URLs that utilize the http:// or https:// protocols</td>
 </tr>
 


### PR DESCRIPTION
Some edits of the OGP.me page correcting typos and grammar.

The term "Open Graph protocol" is used throughout the page except for the types section where the subject is instead "Open Graph." Changed wording twice to better distinguish between the protocol on web pages and the consumed output on a platform.
