### PR TITLE
Unicode, not just UTF-8; fix /ns/class redirect.

### DIFF
--- a/content/index.markdown
+++ b/content/index.markdown
@@ -361,13 +361,13 @@ The following types are used when defining attributes in Open Graph protocol.
 
 <tr>
   <td><a name="string" href="#string">String</td>
-  <td>A sequence of UTF-8 characters</td>
-  <td>All literals composed of UTF-8 characters with no escape characters</td>
+  <td>A sequence of Unicode characters</td>
+  <td>All literals composed of Unicode characters with no escape characters</td>
 </tr>
 
 <tr>
   <td><a name="url" href="#url">URL</td>
-  <td>A sequence of UTF-8 characters that identify an Internet resource.
+  <td>A sequence of Unicode characters that identify an Internet resource.
   <td>All valid URLs that utilize the http:// or https:// protocols</td>
 </tr>
 

--- a/html/ns/.htaccess
+++ b/html/ns/.htaccess
@@ -3,6 +3,6 @@ RewriteEngine On
 RewriteRule fb/(.+) http://graph.facebook.com/schema/og/fb/$1 [L]
 RewriteRule fb/? http://graph.facebook.com/schema/og/ [L]
 RewriteRule / ns/ [L]
+RewriteRule ^/ns/class /ns [L]
 RewriteRule (ogp.me..*) $1 [L]
 RewriteRule ([^/]+) http://graph.facebook.com/schema/og/$1 [L]
-RewriteRule ^/ns/class /ns [L]

--- a/html/ns/ogp.me.rdf
+++ b/html/ns/ogp.me.rdf
@@ -164,14 +164,14 @@
     <rdfs:subClassOf rdf:resource="http://www.w3.org/2001/XMLSchema#string" />
   </rdfs:Datatype>
   <rdfs:Datatype rdf:about="http://ogp.me/ns/class#string">
-    <rdfs:label xml:lang="en-US">UTF-8 encoded string</rdfs:label>
-    <rdfs:comment xml:lang="en-US">A UTF-8 encoded string of Unicode characters.</rdfs:comment>
+    <rdfs:label xml:lang="en-US">Unicode string</rdfs:label>
+    <rdfs:comment xml:lang="en-US">A string of Unicode characters.</rdfs:comment>
     <rdfs:isDefinedBy rdf:resource="http://ogp.me/ns/class#" />
     <rdfs:subClassOf rdf:resource="http://www.w3.org/2001/XMLSchema#string" />
   </rdfs:Datatype>
   <rdfs:Datatype rdf:about="http://ogp.me/ns/class#url">
-    <rdfs:label xml:lang="en-US">UTF-* encoded URL</rdfs:label>
-    <rdfs:comment xml:lang="en-US">A UTF-8 encoded string forming a valid URL having the http or https scheme.</rdfs:comment>
+    <rdfs:label xml:lang="en-US">URL</rdfs:label>
+    <rdfs:comment xml:lang="en-US">A string of Unicode characters forming a valid URL having the http or https scheme.</rdfs:comment>
     <rdfs:isDefinedBy rdf:resource="http://ogp.me/ns/class#" />
     <rdfs:subClassOf rdf:resource="http://ogp.me/ns/class#string" />
   </rdfs:Datatype>

--- a/html/ns/ogp.me.ttl
+++ b/html/ns/ogp.me.ttl
@@ -151,13 +151,13 @@ ogc:integer_str a rdfs:Datatype ;
   rdfs:isDefinedBy ogc: ;
   rdfs:subClassOf xsd:string .
 ogc:string a rdfs:Datatype ;
-  rdfs:label "UTF-8 encoded string"@en-US ;
-  rdfs:comment "A UTF-8 encoded string of Unicode characters."@en-US ;
+  rdfs:label "Unicode string"@en-US ;
+  rdfs:comment "A string of Unicode characters."@en-US ;
   rdfs:isDefinedBy ogc: ;
   rdfs:subClassOf xsd:string .
 ogc:url a rdfs:Datatype ;
-  rdfs:label "UTF-8 encoded URL"@en-US ;
-  rdfs:comment "A UTF-8 encoded string forming a valid URL having the http or https scheme."@en-US ;
+  rdfs:label "URL"@en-US ;
+  rdfs:comment "A string of Unicode characters forming a valid URL having the http or https scheme."@en-US ;
   rdfs:isDefinedBy ogc: ;
   rdfs:subClassOf ogc:string .
 ogc:determiner_str a rdfs:Datatype ;


### PR DESCRIPTION
As previously discussed with @ptarjan, it is too restrictive for an OGP string (see http://ogp.me/#string ) to be UTF-8 encoded.  The lexical space of a datatype should not be concerned with the particular encoding (i.e., UTF-16, EBCDIC, written on paper, etc.), and the present tight coupling of lexical space and encoding has pragmatic problems (e.g., how would one specify a value for og:name in a web page that is not UTF-8 encoded?).  This pull request changes the description of a OGP string to be a string of Unicode characters, independent of encoding.  Also included is a fix for redirection of /ns/class to /ns in order to support Linked Data principles (a simple re-prioritization of the RewriteRule).
