### PR TITLE
Improve descriptions of a profile object's first_name and last_name for a global audience

### DIFF
--- a/content/index.markdown
+++ b/content/index.markdown
@@ -293,8 +293,8 @@ yet are broadly used and agreed upon.
 
 <a name="type_profile" href="#type_profile">`profile`</a> - Namespace URI: [`http://ogp.me/ns/profile#`](http://ogp.me/ns/profile)
 
-* `profile:first_name` - [string](#string) - Their given name.
-* `profile:last_name` - [string](#string) - Their family name.
+* `profile:first_name` - [string](#string) - A name normally given to an individual by a parent or self-chosen.
+* `profile:last_name` - [string](#string) - A name inherited from a family or marriage and by which the individual is commonly known.
 * `profile:username` - [string](#string) - A short unique string to identify them.
 * `profile:gender` - [enum](#enum)(male, female) - Their gender.
 


### PR DESCRIPTION
Expressing one part of an Open Graph protocol group discussion regarding person naming in code form.

The [International Telecommunication Union standard X.520](http://www.itu.int/itu-t/recommendations/rec.aspx?rec=X.520) defines standard ways of referencing a person in a directory while taking into account differences in cultures around the world. The standard forms the basis for vCard and other common computing references to person data. Section 6.2.3 and 6.2.4 of ITU-T X.520 defines a "given name" and a "surname" roughly equal in meaning to Open Graph protocol "first_name" and "last_name" values respectively.

Changing site descriptor text to better match international standard descriptions of a person's name may improve data quality in regions, country, and cultures that do not follow Western-style first and last names.
