### PR TITLE
Link to mixi developer center instead of mailing list announcement.

### DIFF
--- a/content/index.markdown
+++ b/content/index.markdown
@@ -383,7 +383,7 @@ https://www.facebook.com/groups/opengraph/) or on
 http://groups.google.com/group/open-graph-protocol).
 It is currently being consumed by Facebook
 ([see their documentation](
-http://developers.facebook.com/docs/opengraph)), Google ([see their documentation](
+http://developers.facebook.com/docs/opengraph/)), Google ([see their documentation](
 https://developers.google.com/+/plugins/+1button/#plus-snippet)), and
 [mixi](
 http://developer.mixi.co.jp/en/connect/mixi_plugin/mixi_check/spec_mixi_check/).


### PR DESCRIPTION
Mixi has a developer page documenting their use of Open Graph protocol. Better link than a mailing list entry announcing support.
http://developer.mixi.co.jp/en/connect/mixi_plugin/mixi_check/spec_mixi_check/

Facebook link was missing a trailing slash. added that in too.
