### PR TITLE
Remove outdated address in external links section

### DIFF
--- a/content/index.markdown
+++ b/content/index.markdown
@@ -399,8 +399,6 @@ tools. Let the Facebook group know if you've built something awesome too!
 * [Facebook Object Debugger](http://developers.facebook.com/tools/debug/) -
   Facebook's official parser and debugger
 * [Google Rich Snippets Testing Tool](http://www.google.com/webmasters/tools/richsnippets) - Open Graph protocol support in specific verticals and Search Engines.
-* [OpenGraph.in](http://www.opengraph.in/) -
-  a service which parses Open Graph protocol markup and outputs HTML and JSON
 * [PHP Validator and Markup Generator](https://github.com/niallkennedy/open-graph-protocol-tools) -  OGP 2011 input validator and markup generator in PHP5 objects
 * [PHP Consumer](http://github.com/scottmac/opengraph) -
   a small library for accessing of Open Graph Protocol data in PHP


### PR DESCRIPTION
Opengraph.in seems to have expired, or discontinued its service.
