### PR TITLE
Moved prefix to <head>

### DIFF
--- a/content/index.markdown
+++ b/content/index.markdown
@@ -35,8 +35,8 @@ properties for every page are:
 As an example, the following is the Open Graph protocol markup for [The Rock on
 IMDB](http://www.imdb.com/title/tt0117500/):
 
-    <html prefix="og: http://ogp.me/ns#">
-    <head>
+    <html>
+    <head prefix="og: http://ogp.me/ns#">
     <title>The Rock (1996)</title>
     <meta property="og:title" content="The Rock" />
     <meta property="og:type" content="video.movie" />


### PR DESCRIPTION
The source for ogp.me has the `prefix` on the head, so it should be in the example too. This makes it closer to the tags, and is in accordance with feedback from @ptarjan's comment [here](http://stackoverflow.com/questions/8235687/open-graph-namespace-declaration-html-with-xmlns-or-head-prefix#comment16029564_8241755)