### PR TITLE
Lack of newline in markup rendering the WP-plugin description as a header

### DIFF
--- a/content/index.markdown
+++ b/content/index.markdown
@@ -418,4 +418,5 @@ tools. Let the Facebook group know if you've built something awesome too!
   Facebook's official WordPress plugin, which adds Open Graph metadata to WordPress powered sites. 
 * [Alternate WordPress OGP plugin](http://wordpress.org/plugins/wp-facebook-open-graph-protocol/) -
   A simple lightweight WordPress plugin which adds Open Graph metadata to WordPress powered sites.
+
 ---


### PR DESCRIPTION
![screen shot 2015-04-03 at 17 38 38](https://cloud.githubusercontent.com/assets/4328569/6981250/6eecf606-da28-11e4-9530-f0d0e1d119de.png)
