### PR TITLE
add line break before rule

### DIFF
--- a/content/index.markdown
+++ b/content/index.markdown
@@ -419,4 +419,5 @@ tools. Let the Facebook group know if you've built something awesome too!
 * [Alternate WordPress OGP plugin](http://wordpress.org/plugins/wp-facebook-open-graph-protocol/) -
   A simple lightweight WordPress plugin which adds Open Graph metadata to WordPress powered sites.
 
+
 ---


### PR DESCRIPTION
Add line break before final HR, as I assume this is what is causing the last link to be interpreted as a heading:
![screen shot 2015-04-30 at 16 59 45](https://cloud.githubusercontent.com/assets/1764158/7416884/611cacc8-ef5a-11e4-9841-ac39f638e00f.png)
