### PR TITLE
rem FB old official WP plugin link as it's dead

### DIFF
--- a/content/index.markdown
+++ b/content/index.markdown
@@ -414,8 +414,6 @@ tools. Let the Facebook group know if you've built something awesome too!
 * [RDF::RDFa::Parser](
   http://search.cpan.org/~tobyink/RDF-RDFa-Parser/lib/RDF/RDFa/Parser.pm) -
   Perl RDFa parser which understands the Open Graph protocol
-* [WordPress plugin](http://wordpress.org/plugins/facebook/) -
-  Facebook's official WordPress plugin, which adds Open Graph metadata to WordPress powered sites. 
 * [Alternate WordPress OGP plugin](http://wordpress.org/plugins/wp-facebook-open-graph-protocol/) -
   A simple lightweight WordPress plugin which adds Open Graph metadata to WordPress powered sites.
 


### PR DESCRIPTION
The "official" Facebook WordPress plugin is dead and no longer supported - no reason to keep linking to it.