### PR TITLE
Upgrade to PHP Markdown 1.7.0

### DIFF
--- a/lib/Michelf/Markdown.inc.php
+++ b/lib/Michelf/Markdown.inc.php
@@ -1,10 +1,10 @@
 <?php
 
-# Use this file if you cannot use class autoloading. It will include all the
-# files needed for the Markdown parser.
-#
-# Take a look at the PSR-0-compatible class autoloading implementation
-# in the Readme.php file if you want a simple autoloader setup.
+// Use this file if you cannot use class autoloading. It will include all the
+// files needed for the Markdown parser.
+//
+// Take a look at the PSR-0-compatible class autoloading implementation
+// in the Readme.php file if you want a simple autoloader setup.
 
 require_once dirname(__FILE__) . '/MarkdownInterface.php';
 require_once dirname(__FILE__) . '/Markdown.php';

--- a/lib/Michelf/Markdown.php
+++ b/lib/Michelf/Markdown.php
@@ -1,102 +1,158 @@
 <?php
-#
-# Markdown  -  A text-to-HTML conversion tool for web writers
-#
-# PHP Markdown  
-# Copyright (c) 2004-2015 Michel Fortin  
-# <https://michelf.ca/projects/php-markdown/>
-#
-# Original Markdown  
-# Copyright (c) 2004-2006 John Gruber  
-# <http://daringfireball.net/projects/markdown/>
-#
+/**
+ * Markdown  -  A text-to-HTML conversion tool for web writers
+ *
+ * @package   php-markdown
+ * @author    Michel Fortin <michel.fortin@michelf.com>
+ * @copyright 2004-2016 Michel Fortin <https://michelf.com/projects/php-markdown/>
+ * @copyright (Original Markdown) 2004-2006 John Gruber <https://daringfireball.net/projects/markdown/>
+ */
+
 namespace Michelf;
 
-
-#
-# Markdown Parser Class
-#
-
+/**
+ * Markdown Parser Class
+ */
 class Markdown implements MarkdownInterface {
+	/**
+	 * Define the package version
+	 * @var string
+	 */
+	const MARKDOWNLIB_VERSION = "1.7.0";
 
-	### Version ###
-
-	const  MARKDOWNLIB_VERSION  =  "1.5.0";
-
-	### Simple Function Interface ###
-
+	/**
+	 * Simple function interface - Initialize the parser and return the result
+	 * of its transform method. This will work fine for derived classes too.
+	 *
+	 * @api
+	 *
+	 * @param  string $text
+	 * @return string
+	 */
 	public static function defaultTransform($text) {
-	#
-	# Initialize the parser and return the result of its transform method.
-	# This will work fine for derived classes too.
-	#
-		# Take parser class on which this function was called.
+		// Take parser class on which this function was called.
 		$parser_class = \get_called_class();
 
-		# try to take parser from the static parser list
+		// Try to take parser from the static parser list
 		static $parser_list;
 		$parser =& $parser_list[$parser_class];
 
-		# create the parser it not already set
-		if (!$parser)
+		// Create the parser it not already set
+		if (!$parser) {
 			$parser = new $parser_class;
+		}
 
-		# Transform text using parser.
+		// Transform text using parser.
 		return $parser->transform($text);
 	}
 
-	### Configuration Variables ###
+	/**
+	 * Configuration variables
+	 */
 
-	# Change to ">" for HTML output.
+	/**
+	 * Change to ">" for HTML output.
+	 * @var string
+	 */
 	public $empty_element_suffix = " />";
+
+	/**
+	 * The width of indentation of the output markup
+	 * @var int
+	 */
 	public $tab_width = 4;
 	
-	# Change to `true` to disallow markup or entities.
-	public $no_markup = false;
+	/**
+	 * Change to `true` to disallow markup or entities.
+	 * @var boolean
+	 */
+	public $no_markup   = false;
 	public $no_entities = false;
 	
-	# Predefined urls and titles for reference links and images.
-	public $predef_urls = array();
+
+	/**
+	 * Change to `true` to enable line breaks on \n without two trailling spaces
+	 * @var boolean
+	 */
+	public $hard_wrap = false;
+
+	/**
+	 * Predefined URLs and titles for reference links and images.
+	 * @var array
+	 */
+	public $predef_urls   = array();
 	public $predef_titles = array();
 
-	# Optional filter function for URLs
+	/**
+	 * Optional filter function for URLs
+	 * @var callable
+	 */
 	public $url_filter_func = null;
 
-	# Optional header id="" generation callback function.
+	/**
+	 * Optional header id="" generation callback function.
+	 * @var callable
+	 */
 	public $header_id_func = null;
+	
+	/**
+	 * Optional function for converting code block content to HTML
+	 * @var callable
+	 */
+	public $code_block_content_func = null;
 
-	# Class attribute to toggle "enhanced ordered list" behaviour
-	# setting this to true will allow ordered lists to start from the index
-	# number that is defined first.  For example:
-	# 2. List item two
-	# 3. List item three
-	# 
-	# becomes
-	# <ol start="2">
-	# <li>List item two</li>
-	# <li>List item three</li>
-	# </ol>
+	/**
+	 * Optional function for converting code span content to HTML.
+	 * @var callable
+	 */
+	public $code_span_content_func = null;
+
+	/**
+	 * Class attribute to toggle "enhanced ordered list" behaviour
+	 * setting this to true will allow ordered lists to start from the index
+	 * number that is defined first.
+	 * 
+	 * For example:
+	 * 2. List item two
+	 * 3. List item three
+	 *
+	 * Becomes:
+	 * <ol start="2">
+	 * <li>List item two</li>
+	 * <li>List item three</li>
+	 * </ol>
+	 *
+	 * @var bool
+	 */
 	public $enhanced_ordered_list = false;
 
-	### Parser Implementation ###
+	/**
+	 * Parser implementation
+	 */
 
-	# Regex to match balanced [brackets].
-	# Needed to insert a maximum bracked depth while converting to PHP.
+	/**
+	 * Regex to match balanced [brackets].
+	 * Needed to insert a maximum bracked depth while converting to PHP.
+	 * @var int
+	 */
 	protected $nested_brackets_depth = 6;
 	protected $nested_brackets_re;
-	
+
 	protected $nested_url_parenthesis_depth = 4;
 	protected $nested_url_parenthesis_re;
 
-	# Table of hash values for escaped characters:
+	/**
+	 * Table of hash values for escaped characters:
+	 * @var string
+	 */
 	protected $escape_chars = '\`*_{}[]()>#+-.!';
 	protected $escape_chars_re;
 
-
+	/**
+	 * Constructor function. Initialize appropriate member variables.
+	 * @return void
+	 */
 	public function __construct() {
-	#
-	# Constructor function. Initialize appropriate member variables.
-	#
 		$this->_initDetab();
 		$this->prepareItalicsAndBold();
 	
@@ -110,51 +166,60 @@ class Markdown implements MarkdownInterface {
 		
 		$this->escape_chars_re = '['.preg_quote($this->escape_chars).']';
 		
-		# Sort document, block, and span gamut in ascendent priority order.
+		// Sort document, block, and span gamut in ascendent priority order.
 		asort($this->document_gamut);
 		asort($this->block_gamut);
 		asort($this->span_gamut);
 	}
 
 
-	# Internal hashes used during transformation.
-	protected $urls = array();
-	protected $titles = array();
+	/**
+	 * Internal hashes used during transformation.
+	 * @var array
+	 */
+	protected $urls        = array();
+	protected $titles      = array();
 	protected $html_hashes = array();
 	
-	# Status flag to avoid invalid nesting.
+	/**
+	 * Status flag to avoid invalid nesting.
+	 * @var boolean
+	 */
 	protected $in_anchor = false;
 	
-	
+	/**
+	 * Called before the transformation process starts to setup parser states.
+	 * @return void
+	 */
 	protected function setup() {
-	#
-	# Called before the transformation process starts to setup parser 
-	# states.
-	#
-		# Clear global hashes.
-		$this->urls = $this->predef_urls;
-		$this->titles = $this->predef_titles;
+		// Clear global hashes.
+		$this->urls        = $this->predef_urls;
+		$this->titles      = $this->predef_titles;
 		$this->html_hashes = array();
-		
-		$this->in_anchor = false;
+		$this->in_anchor   = false;
 	}
 	
+	/**
+	 * Called after the transformation process to clear any variable which may
+	 * be taking up memory unnecessarly.
+	 * @return void
+	 */
 	protected function teardown() {
-	#
-	# Called after the transformation process to clear any variable 
-	# which may be taking up memory unnecessarly.
-	#
-		$this->urls = array();
-		$this->titles = array();
+		$this->urls        = array();
+		$this->titles      = array();
 		$this->html_hashes = array();
 	}
 
-
+	/**
+	 * Main function. Performs some preprocessing on the input text and pass
+	 * it through the document gamut.
+	 *
+	 * @api
+	 *
+	 * @param  string $text
+	 * @return string
+	 */
 	public function transform($text) {
-	#
-	# Main function. Performs some preprocessing on the input text
-	# and pass it through the document gamut.
-	#
 		$this->setup();
 	
 		# Remove UTF-8 BOM and marker character in input, if present.
@@ -188,23 +253,28 @@ class Markdown implements MarkdownInterface {
 
 		return $text . "\n";
 	}
-	
+
+	/**
+	 * Define the document gamut
+	 * @var array
+	 */
 	protected $document_gamut = array(
-		# Strip link definitions, store in hashes.
+		// Strip link definitions, store in hashes.
 		"stripLinkDefinitions" => 20,
-		
 		"runBasicBlockGamut"   => 30,
-		);
+	);
 
-
+	/**
+	 * Strips link definitions from text, stores the URLs and titles in
+	 * hash references
+	 * @param  string $text
+	 * @return string
+	 */
 	protected function stripLinkDefinitions($text) {
-	#
-	# Strips link definitions from text, stores the URLs and titles in
-	# hash references.
-	#
+	
 		$less_than_tab = $this->tab_width - 1;
 
-		# Link defs are in the form: ^[id]: url "optional title"
+		// Link defs are in the form: ^[id]: url "optional title"
 		$text = preg_replace_callback('{
 							^[ ]{0,'.$less_than_tab.'}\[(.+)\][ ]?:	# id = $1
 							  [ ]*
@@ -228,43 +298,58 @@ class Markdown implements MarkdownInterface {
 							(?:\n+|\Z)
 			}xm',
 			array($this, '_stripLinkDefinitions_callback'),
-			$text);
+			$text
+		);
 		return $text;
 	}
+
+	/**
+	 * The callback to strip link definitions
+	 * @param  array $matches
+	 * @return string
+	 */
 	protected function _stripLinkDefinitions_callback($matches) {
 		$link_id = strtolower($matches[1]);
 		$url = $matches[2] == '' ? $matches[3] : $matches[2];
 		$this->urls[$link_id] = $url;
 		$this->titles[$link_id] =& $matches[4];
-		return ''; # String that will replace the block
+		return ''; // String that will replace the block
 	}
 
-
+	/**
+	 * Hashify HTML blocks
+	 * @param  string $text
+	 * @return string
+	 */
 	protected function hashHTMLBlocks($text) {
-		if ($this->no_markup)  return $text;
+		if ($this->no_markup) {
+			return $text;
+		}
 
 		$less_than_tab = $this->tab_width - 1;
 
-		# Hashify HTML blocks:
-		# We only want to do this for block-level HTML tags, such as headers,
-		# lists, and tables. That's because we still want to wrap <p>s around
-		# "paragraphs" that are wrapped in non-block-level tags, such as anchors,
-		# phrase emphasis, and spans. The list of tags we're looking for is
-		# hard-coded:
-		#
-		# *  List "a" is made of tags which can be both inline or block-level.
-		#    These will be treated block-level when the start tag is alone on 
-		#    its line, otherwise they're not matched here and will be taken as 
-		#    inline later.
-		# *  List "b" is made of tags which are always block-level;
-		#
+		/**
+		 * Hashify HTML blocks:
+		 *
+		 * We only want to do this for block-level HTML tags, such as headers,
+		 * lists, and tables. That's because we still want to wrap <p>s around
+		 * "paragraphs" that are wrapped in non-block-level tags, such as
+		 * anchors, phrase emphasis, and spans. The list of tags we're looking
+		 * for is hard-coded:
+		 *
+		 * *  List "a" is made of tags which can be both inline or block-level.
+		 *    These will be treated block-level when the start tag is alone on 
+		 *    its line, otherwise they're not matched here and will be taken as 
+		 *    inline later.
+		 * *  List "b" is made of tags which are always block-level;
+		 */
 		$block_tags_a_re = 'ins|del';
 		$block_tags_b_re = 'p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|address|'.
 						   'script|noscript|style|form|fieldset|iframe|math|svg|'.
 						   'article|section|nav|aside|hgroup|header|footer|'.
 						   'figure';
 
-		# Regular expression for the content of a block tag.
+		// Regular expression for the content of a block tag.
 		$nested_tags_level = 4;
 		$attr = '
 			(?>				# optional tag attributes
@@ -290,8 +375,8 @@ class Markdown implements MarkdownInterface {
 					(?>
 					  />
 					|
-					  >', $nested_tags_level).	# end of opening tag
-					  '.*?'.					# last level nested tag content
+					  >', $nested_tags_level).	// end of opening tag
+					  '.*?'.					// last level nested tag content
 			str_repeat('
 					  </\2\s*>	# closing nested tag
 					)
@@ -302,17 +387,20 @@ class Markdown implements MarkdownInterface {
 				$nested_tags_level);
 		$content2 = str_replace('\2', '\3', $content);
 
-		# First, look for nested blocks, e.g.:
-		# 	<div>
-		# 		<div>
-		# 		tags for inner block must be indented.
-		# 		</div>
-		# 	</div>
-		#
-		# The outermost tags must start at the left margin for this to match, and
-		# the inner nested divs must be indented.
-		# We need to do this before the next, more liberal match, because the next
-		# match will start at the first `<div>` and stop at the first `</div>`.
+		/**
+		 * First, look for nested blocks, e.g.:
+		 * 	<div>
+		 * 		<div>
+		 * 		tags for inner block must be indented.
+		 * 		</div>
+		 * 	</div>
+		 *
+		 * The outermost tags must start at the left margin for this to match,
+		 * and the inner nested divs must be indented.
+		 * We need to do this before the next, more liberal match, because the
+		 * next match will start at the first `<div>` and stop at the
+		 * first `</div>`.
+		 */
 		$text = preg_replace_callback('{(?>
 			(?>
 				(?<=\n)			# Starting on its own line
@@ -375,94 +463,114 @@ class Markdown implements MarkdownInterface {
 			)
 			)}Sxmi',
 			array($this, '_hashHTMLBlocks_callback'),
-			$text);
+			$text
+		);
 
 		return $text;
 	}
+
+	/**
+	 * The callback for hashing HTML blocks
+	 * @param  string $matches
+	 * @return string
+	 */
 	protected function _hashHTMLBlocks_callback($matches) {
 		$text = $matches[1];
 		$key  = $this->hashBlock($text);
 		return "\n\n$key\n\n";
 	}
 	
-	
+	/**
+	 * Called whenever a tag must be hashed when a function insert an atomic 
+	 * element in the text stream. Passing $text to through this function gives
+	 * a unique text-token which will be reverted back when calling unhash.
+	 *
+	 * The $boundary argument specify what character should be used to surround
+	 * the token. By convension, "B" is used for block elements that needs not
+	 * to be wrapped into paragraph tags at the end, ":" is used for elements
+	 * that are word separators and "X" is used in the general case.
+	 *
+	 * @param  string $text
+	 * @param  string $boundary
+	 * @return string
+	 */
 	protected function hashPart($text, $boundary = 'X') {
-	#
-	# Called whenever a tag must be hashed when a function insert an atomic 
-	# element in the text stream. Passing $text to through this function gives
-	# a unique text-token which will be reverted back when calling unhash.
-	#
-	# The $boundary argument specify what character should be used to surround
-	# the token. By convension, "B" is used for block elements that needs not
-	# to be wrapped into paragraph tags at the end, ":" is used for elements
-	# that are word separators and "X" is used in the general case.
-	#
-		# Swap back any tag hash found in $text so we do not have to `unhash`
-		# multiple times at the end.
+		// Swap back any tag hash found in $text so we do not have to `unhash`
+		// multiple times at the end.
 		$text = $this->unhash($text);
 		
-		# Then hash the block.
+		// Then hash the block.
 		static $i = 0;
 		$key = "$boundary\x1A" . ++$i . $boundary;
 		$this->html_hashes[$key] = $text;
-		return $key; # String that will replace the tag.
+		return $key; // String that will replace the tag.
 	}
 
-
+	/**
+	 * Shortcut function for hashPart with block-level boundaries.
+	 * @param  string $text
+	 * @return string
+	 */
 	protected function hashBlock($text) {
-	#
-	# Shortcut function for hashPart with block-level boundaries.
-	#
 		return $this->hashPart($text, 'B');
 	}
 
-
+	/**
+	 * Define the block gamut - these are all the transformations that form
+	 * block-level tags like paragraphs, headers, and list items.
+	 * @var array
+	 */
 	protected $block_gamut = array(
-	#
-	# These are all the transformations that form block-level
-	# tags like paragraphs, headers, and list items.
-	#
 		"doHeaders"         => 10,
 		"doHorizontalRules" => 20,
-		
 		"doLists"           => 40,
 		"doCodeBlocks"      => 50,
 		"doBlockQuotes"     => 60,
-		);
+	);
 
+	/**
+	 * Run block gamut tranformations.
+	 *
+	 * We need to escape raw HTML in Markdown source before doing anything 
+	 * else. This need to be done for each block, and not only at the 
+	 * begining in the Markdown function since hashed blocks can be part of
+	 * list items and could have been indented. Indented blocks would have 
+	 * been seen as a code block in a previous pass of hashHTMLBlocks.
+	 *
+	 * @param  string $text
+	 * @return string
+	 */
 	protected function runBlockGamut($text) {
-	#
-	# Run block gamut tranformations.
-	#
-		# We need to escape raw HTML in Markdown source before doing anything 
-		# else. This need to be done for each block, and not only at the 
-		# begining in the Markdown function since hashed blocks can be part of
-		# list items and could have been indented. Indented blocks would have 
-		# been seen as a code block in a previous pass of hashHTMLBlocks.
 		$text = $this->hashHTMLBlocks($text);
-		
 		return $this->runBasicBlockGamut($text);
 	}
-	
+
+	/**
+	 * Run block gamut tranformations, without hashing HTML blocks. This is 
+	 * useful when HTML blocks are known to be already hashed, like in the first
+	 * whole-document pass.
+	 *
+	 * @param  string $text
+	 * @return string
+	 */
 	protected function runBasicBlockGamut($text) {
-	#
-	# Run block gamut tranformations, without hashing HTML blocks. This is 
-	# useful when HTML blocks are known to be already hashed, like in the first
-	# whole-document pass.
-	#
+	
 		foreach ($this->block_gamut as $method => $priority) {
 			$text = $this->$method($text);
 		}
 		
-		# Finally form paragraph and restore hashed blocks.
+		// Finally form paragraph and restore hashed blocks.
 		$text = $this->formParagraphs($text);
 
 		return $text;
 	}
-	
-	
+
+	/**
+	 * Convert horizontal rules
+	 * @param  string $text
+	 * @return string
+	 */
 	protected function doHorizontalRules($text) {
-		# Do Horizontal Rules:
 		return preg_replace(
 			'{
 				^[ ]{0,3}	# Leading space
@@ -475,66 +583,81 @@ class Markdown implements MarkdownInterface {
 				$			# End of line.
 			}mx',
 			"\n".$this->hashBlock("<hr$this->empty_element_suffix")."\n", 
-			$text);
+			$text
+		);
 	}
 
-
+	/**
+	 * These are all the transformations that occur *within* block-level
+	 * tags like paragraphs, headers, and list items.
+	 * @var array
+	 */
 	protected $span_gamut = array(
-	#
-	# These are all the transformations that occur *within* block-level
-	# tags like paragraphs, headers, and list items.
-	#
-		# Process character escapes, code spans, and inline HTML
-		# in one shot.
+		// Process character escapes, code spans, and inline HTML
+		// in one shot.
 		"parseSpan"           => -30,
-
-		# Process anchor and image tags. Images must come first,
-		# because ![foo][f] looks like an anchor.
+		// Process anchor and image tags. Images must come first,
+		// because ![foo][f] looks like an anchor.
 		"doImages"            =>  10,
 		"doAnchors"           =>  20,
-		
-		# Make links out of things like `<http://example.com/>`
-		# Must come after doAnchors, because you can use < and >
-		# delimiters in inline links like [this](<url>).
+		// Make links out of things like `<https://example.com/>`
+		// Must come after doAnchors, because you can use < and >
+		// delimiters in inline links like [this](<url>).
 		"doAutoLinks"         =>  30,
 		"encodeAmpsAndAngles" =>  40,
-
 		"doItalicsAndBold"    =>  50,
 		"doHardBreaks"        =>  60,
-		);
+	);
 
+	/**
+	 * Run span gamut transformations
+	 * @param  string $text
+	 * @return string
+	 */
 	protected function runSpanGamut($text) {
-	#
-	# Run span gamut tranformations.
-	#
 		foreach ($this->span_gamut as $method => $priority) {
 			$text = $this->$method($text);
 		}
 
 		return $text;
 	}
-	
-	
+
+	/**
+	 * Do hard breaks
+	 * @param  string $text
+	 * @return string
+	 */
 	protected function doHardBreaks($text) {
-		# Do hard breaks:
-		return preg_replace_callback('/ {2,}\n/', 
-			array($this, '_doHardBreaks_callback'), $text);
+		if ($this->hard_wrap) {
+			return preg_replace_callback('/ *\n/', 
+				array($this, '_doHardBreaks_callback'), $text);
+		} else {
+			return preg_replace_callback('/ {2,}\n/', 
+				array($this, '_doHardBreaks_callback'), $text);
+		}
 	}
+
+	/**
+	 * Trigger part hashing for the hard break (callback method)
+	 * @param  array $matches
+	 * @return string
+	 */
 	protected function _doHardBreaks_callback($matches) {
 		return $this->hashPart("<br$this->empty_element_suffix\n");
 	}
 
-
+	/**
+	 * Turn Markdown link shortcuts into XHTML <a> tags.
+	 * @param  string $text
+	 * @return string
+	 */
 	protected function doAnchors($text) {
-	#
-	# Turn Markdown link shortcuts into XHTML <a> tags.
-	#
-		if ($this->in_anchor) return $text;
+		if ($this->in_anchor) {
+			return $text;
+		}
 		$this->in_anchor = true;
 		
-		#
-		# First, handle reference-style links: [link text] [id]
-		#
+		// First, handle reference-style links: [link text] [id]
 		$text = preg_replace_callback('{
 			(					# wrap whole match in $1
 			  \[
@@ -551,9 +674,7 @@ class Markdown implements MarkdownInterface {
 			}xs',
 			array($this, '_doAnchors_reference_callback'), $text);
 
-		#
-		# Next, inline-style links: [link text](url "optional title")
-		#
+		// Next, inline-style links: [link text](url "optional title")
 		$text = preg_replace_callback('{
 			(				# wrap whole match in $1
 			  \[
@@ -578,11 +699,9 @@ class Markdown implements MarkdownInterface {
 			}xs',
 			array($this, '_doAnchors_inline_callback'), $text);
 
-		#
-		# Last, handle reference-style shortcuts: [link text]
-		# These must come last in case you've also got [link text][1]
-		# or [link text](/foo)
-		#
+		// Last, handle reference-style shortcuts: [link text]
+		// These must come last in case you've also got [link text][1]
+		// or [link text](/foo)
 		$text = preg_replace_callback('{
 			(					# wrap whole match in $1
 			  \[
@@ -595,17 +714,23 @@ class Markdown implements MarkdownInterface {
 		$this->in_anchor = false;
 		return $text;
 	}
+
+	/**
+	 * Callback method to parse referenced anchors
+	 * @param  string $matches
+	 * @return string
+	 */
 	protected function _doAnchors_reference_callback($matches) {
 		$whole_match =  $matches[1];
 		$link_text   =  $matches[2];
 		$link_id     =& $matches[3];
 
 		if ($link_id == "") {
-			# for shortcut links like [this][] or [this].
+			// for shortcut links like [this][] or [this].
 			$link_id = $link_text;
 		}
 		
-		# lower-case and turn embedded newlines into spaces
+		// lower-case and turn embedded newlines into spaces
 		$link_id = strtolower($link_id);
 		$link_id = preg_replace('{[ ]?\n}', ' ', $link_id);
 
@@ -623,20 +748,26 @@ class Markdown implements MarkdownInterface {
 			$link_text = $this->runSpanGamut($link_text);
 			$result .= ">$link_text</a>";
 			$result = $this->hashPart($result);
-		}
-		else {
+		} else {
 			$result = $whole_match;
 		}
 		return $result;
 	}
+
+	/**
+	 * Callback method to parse inline anchors
+	 * @param  string $matches
+	 * @return string
+	 */
 	protected function _doAnchors_inline_callback($matches) {
 		$whole_match	=  $matches[1];
 		$link_text		=  $this->runSpanGamut($matches[2]);
 		$url			=  $matches[3] == '' ? $matches[4] : $matches[3];
 		$title			=& $matches[7];
 
-		// if the URL was of the form <s p a c e s> it got caught by the HTML
-		// tag parser and hashed. Need to reverse the process before using the URL.
+		// If the URL was of the form <s p a c e s> it got caught by the HTML
+		// tag parser and hashed. Need to reverse the process before using
+		// the URL.
 		$unhashed = $this->unhash($url);
 		if ($unhashed != $url)
 			$url = preg_replace('/^<(.*)>$/', '\1', $unhashed);
@@ -655,14 +786,13 @@ class Markdown implements MarkdownInterface {
 		return $this->hashPart($result);
 	}
 
-
+	/**
+	 * Turn Markdown image shortcuts into <img> tags.
+	 * @param  string $text
+	 * @return string
+	 */
 	protected function doImages($text) {
-	#
-	# Turn Markdown image shortcuts into <img> tags.
-	#
-		#
-		# First, handle reference-style labeled images: ![alt text][id]
-		#
+		// First, handle reference-style labeled images: ![alt text][id]
 		$text = preg_replace_callback('{
 			(				# wrap whole match in $1
 			  !\[
@@ -680,10 +810,8 @@ class Markdown implements MarkdownInterface {
 			}xs', 
 			array($this, '_doImages_reference_callback'), $text);
 
-		#
-		# Next, handle inline images:  ![alt text](url "optional title")
-		# Don't forget: encode * and _
-		#
+		// Next, handle inline images:  ![alt text](url "optional title")
+		// Don't forget: encode * and _
 		$text = preg_replace_callback('{
 			(				# wrap whole match in $1
 			  !\[
@@ -711,13 +839,19 @@ class Markdown implements MarkdownInterface {
 
 		return $text;
 	}
+
+	/**
+	 * Callback to parse references image tags
+	 * @param  array $matches
+	 * @return string
+	 */
 	protected function _doImages_reference_callback($matches) {
 		$whole_match = $matches[1];
 		$alt_text    = $matches[2];
 		$link_id     = strtolower($matches[3]);
 
 		if ($link_id == "") {
-			$link_id = strtolower($alt_text); # for shortcut links like ![this][].
+			$link_id = strtolower($alt_text); // for shortcut links like ![this][].
 		}
 
 		$alt_text = $this->encodeAttribute($alt_text);
@@ -731,14 +865,19 @@ class Markdown implements MarkdownInterface {
 			}
 			$result .= $this->empty_element_suffix;
 			$result = $this->hashPart($result);
-		}
-		else {
-			# If there's no such link ID, leave intact:
+		} else {
+			// If there's no such link ID, leave intact:
 			$result = $whole_match;
 		}
 
 		return $result;
 	}
+
+	/**
+	 * Callback to parse inline image tags
+	 * @param  array $matches
+	 * @return string
+	 */
 	protected function _doImages_inline_callback($matches) {
 		$whole_match	= $matches[1];
 		$alt_text		= $matches[2];
@@ -750,32 +889,38 @@ class Markdown implements MarkdownInterface {
 		$result = "<img src=\"$url\" alt=\"$alt_text\"";
 		if (isset($title)) {
 			$title = $this->encodeAttribute($title);
-			$result .=  " title=\"$title\""; # $title already quoted
+			$result .=  " title=\"$title\""; // $title already quoted
 		}
 		$result .= $this->empty_element_suffix;
 
 		return $this->hashPart($result);
 	}
 
-
+	/**
+	 * Parse Markdown heading elements to HTML
+	 * @param  string $text
+	 * @return string
+	 */
 	protected function doHeaders($text) {
-		# Setext-style headers:
-		#	  Header 1
-		#	  ========
-		#  
-		#	  Header 2
-		#	  --------
-		#
+		/**
+		 * Setext-style headers:
+		 *	  Header 1
+		 *	  ========
+		 *  
+		 *	  Header 2
+		 *	  --------
+		 */
 		$text = preg_replace_callback('{ ^(.+?)[ ]*\n(=+|-+)[ ]*\n+ }mx',
 			array($this, '_doHeaders_callback_setext'), $text);
 
-		# atx-style headers:
-		#	# Header 1
-		#	## Header 2
-		#	## Header 2 with closing hashes ##
-		#	...
-		#	###### Header 6
-		#
+		/**
+		 * atx-style headers:
+		 *   # Header 1
+		 *   ## Header 2
+		 *   ## Header 2 with closing hashes ##
+		 *   ...
+		 *   ###### Header 6
+		 */
 		$text = preg_replace_callback('{
 				^(\#{1,6})	# $1 = string of #\'s
 				[ ]*
@@ -789,22 +934,33 @@ class Markdown implements MarkdownInterface {
 		return $text;
 	}
 
+	/**
+	 * Setext header parsing callback
+	 * @param  array $matches
+	 * @return string
+	 */
 	protected function _doHeaders_callback_setext($matches) {
-		# Terrible hack to check we haven't found an empty list item.
-		if ($matches[2] == '-' && preg_match('{^-(?: |$)}', $matches[1]))
+		// Terrible hack to check we haven't found an empty list item.
+		if ($matches[2] == '-' && preg_match('{^-(?: |$)}', $matches[1])) {
 			return $matches[0];
+		}
 		
 		$level = $matches[2]{0} == '=' ? 1 : 2;
 
-		# id attribute generation
+		// ID attribute generation
 		$idAtt = $this->_generateIdFromHeaderValue($matches[1]);
 
 		$block = "<h$level$idAtt>".$this->runSpanGamut($matches[1])."</h$level>";
 		return "\n" . $this->hashBlock($block) . "\n\n";
 	}
-	protected function _doHeaders_callback_atx($matches) {
 
-		# id attribute generation
+	/**
+	 * ATX header parsing callback
+	 * @param  array $matches
+	 * @return string
+	 */
+	protected function _doHeaders_callback_atx($matches) {
+		// ID attribute generation
 		$idAtt = $this->_generateIdFromHeaderValue($matches[2]);
 
 		$level = strlen($matches[1]);
@@ -812,30 +968,37 @@ class Markdown implements MarkdownInterface {
 		return "\n" . $this->hashBlock($block) . "\n\n";
 	}
 
-	protected function _generateIdFromHeaderValue($headerValue) {
-
-		# if a header_id_func property is set, we can use it to automatically
-		# generate an id attribute.
-		#
-		# This method returns a string in the form id="foo", or an empty string
-		# otherwise.
+	/**
+	 * If a header_id_func property is set, we can use it to automatically
+	 * generate an id attribute.
+	 *
+	 * This method returns a string in the form id="foo", or an empty string
+	 * otherwise.
+	 * @param  string $headerValue
+	 * @return string
+	 */
+	protected function _generateIdFromHeaderValue($headerValue) {		
 		if (!is_callable($this->header_id_func)) {
 			return "";
 		}
+
 		$idValue = call_user_func($this->header_id_func, $headerValue);
-		if (!$idValue) return "";
+		if (!$idValue) {
+			return "";
+		}
 
 		return ' id="' . $this->encodeAttribute($idValue) . '"';
-
 	}
 
+	/**
+	 * Form HTML ordered (numbered) and unordered (bulleted) lists.
+	 * @param  string $text
+	 * @return string
+	 */
 	protected function doLists($text) {
-	#
-	# Form HTML ordered (numbered) and unordered (bulleted) lists.
-	#
 		$less_than_tab = $this->tab_width - 1;
 
-		# Re-usable patterns to match list item bullets and number markers:
+		// Re-usable patterns to match list item bullets and number markers:
 		$marker_ul_re  = '[*+-]';
 		$marker_ol_re  = '\d+[\.]';
 
@@ -845,7 +1008,7 @@ class Markdown implements MarkdownInterface {
 			);
 
 		foreach ($markers_relist as $marker_re => $other_marker_re) {
-			# Re-usable pattern to match any entirel ul or ol list:
+			// Re-usable pattern to match any entirel ul or ol list:
 			$whole_list_re = '
 				(								# $1 = whole list
 				  (								# $2
@@ -873,8 +1036,8 @@ class Markdown implements MarkdownInterface {
 				)
 			'; // mx
 			
-			# We use a different prefix before nested lists than top-level lists.
-			# See extended comment in _ProcessListItems().
+			// We use a different prefix before nested lists than top-level lists.
+			//See extended comment in _ProcessListItems().
 		
 			if ($this->list_level) {
 				$text = preg_replace_callback('{
@@ -882,8 +1045,7 @@ class Markdown implements MarkdownInterface {
 						'.$whole_list_re.'
 					}mx',
 					array($this, '_doLists_callback'), $text);
-			}
-			else {
+			} else {
 				$text = preg_replace_callback('{
 						(?:(?<=\n)\n|\A\n?) # Must eat the newline
 						'.$whole_list_re.'
@@ -894,8 +1056,14 @@ class Markdown implements MarkdownInterface {
 
 		return $text;
 	}
+
+	/**
+	 * List parsing callback
+	 * @param  array $matches
+	 * @return string
+	 */
 	protected function _doLists_callback($matches) {
-		# Re-usable patterns to match list item bullets and number markers:
+		// Re-usable patterns to match list item bullets and number markers:
 		$marker_ul_re  = '[*+-]';
 		$marker_ol_re  = '\d+[\.]';
 		$marker_any_re = "(?:$marker_ul_re|$marker_ol_re)";
@@ -911,7 +1079,7 @@ class Markdown implements MarkdownInterface {
 
 		$ol_start = 1;
 		if ($this->enhanced_ordered_list) {
-			# Get the start number for ordered list.
+			// Get the start number for ordered list.
 			if ($list_type == 'ol') {
 				$ol_start_array = array();
 				$ol_start_check = preg_match("/$marker_ol_start_re/", $matches[4], $ol_start_array);
@@ -929,37 +1097,45 @@ class Markdown implements MarkdownInterface {
 		return "\n". $result ."\n\n";
 	}
 
+	/**
+	 * Nesting tracker for list levels
+	 * @var integer
+	 */
 	protected $list_level = 0;
 
+	/**
+	 * Process the contents of a single ordered or unordered list, splitting it
+	 * into individual list items.
+	 * @param  string $list_str
+	 * @param  string $marker_any_re
+	 * @return string
+	 */
 	protected function processListItems($list_str, $marker_any_re) {
-	#
-	#	Process the contents of a single ordered or unordered list, splitting it
-	#	into individual list items.
-	#
-		# The $this->list_level global keeps track of when we're inside a list.
-		# Each time we enter a list, we increment it; when we leave a list,
-		# we decrement. If it's zero, we're not in a list anymore.
-		#
-		# We do this because when we're not inside a list, we want to treat
-		# something like this:
-		#
-		#		I recommend upgrading to version
-		#		8. Oops, now this line is treated
-		#		as a sub-list.
-		#
-		# As a single paragraph, despite the fact that the second line starts
-		# with a digit-period-space sequence.
-		#
-		# Whereas when we're inside a list (or sub-list), that line will be
-		# treated as the start of a sub-list. What a kludge, huh? This is
-		# an aspect of Markdown's syntax that's hard to parse perfectly
-		# without resorting to mind-reading. Perhaps the solution is to
-		# change the syntax rules such that sub-lists must start with a
-		# starting cardinal number; e.g. "1." or "a.".
-		
+		/**
+		 * The $this->list_level global keeps track of when we're inside a list.
+		 * Each time we enter a list, we increment it; when we leave a list,
+		 * we decrement. If it's zero, we're not in a list anymore.
+		 *
+		 * We do this because when we're not inside a list, we want to treat
+		 * something like this:
+		 *
+		 *		I recommend upgrading to version
+		 *		8. Oops, now this line is treated
+		 *		as a sub-list.
+		 *
+		 * As a single paragraph, despite the fact that the second line starts
+		 * with a digit-period-space sequence.
+		 *
+		 * Whereas when we're inside a list (or sub-list), that line will be
+		 * treated as the start of a sub-list. What a kludge, huh? This is
+		 * an aspect of Markdown's syntax that's hard to parse perfectly
+		 * without resorting to mind-reading. Perhaps the solution is to
+		 * change the syntax rules such that sub-lists must start with a
+		 * starting cardinal number; e.g. "1." or "a.".
+		 */		
 		$this->list_level++;
 
-		# trim trailing blank lines:
+		// Trim trailing blank lines:
 		$list_str = preg_replace("/\n{2,}\\z/", "\n", $list_str);
 
 		$list_str = preg_replace_callback('{
@@ -977,6 +1153,12 @@ class Markdown implements MarkdownInterface {
 		$this->list_level--;
 		return $list_str;
 	}
+
+	/**
+	 * List item parsing callback
+	 * @param  array $matches
+	 * @return string
+	 */
 	protected function _processListItems_callback($matches) {
 		$item = $matches[4];
 		$leading_line =& $matches[1];
@@ -987,25 +1169,24 @@ class Markdown implements MarkdownInterface {
 		if ($leading_line || $tailing_blank_line || 
 			preg_match('/\n{2,}/', $item))
 		{
-			# Replace marker with the appropriate whitespace indentation
+			// Replace marker with the appropriate whitespace indentation
 			$item = $leading_space . str_repeat(' ', strlen($marker_space)) . $item;
 			$item = $this->runBlockGamut($this->outdent($item)."\n");
-		}
-		else {
-			# Recursion for sub-lists:
+		} else {
+			// Recursion for sub-lists:
 			$item = $this->doLists($this->outdent($item));
-			$item = preg_replace('/\n+$/', '', $item);
-			$item = $this->runSpanGamut($item);
+			$item = $this->formParagraphs($item, false);
 		}
 
 		return "<li>" . $item . "</li>\n";
 	}
 
-
+	/**
+	 * Process Markdown `<pre><code>` blocks.
+	 * @param  string $text
+	 * @return string
+	 */
 	protected function doCodeBlocks($text) {
-	#
-	#	Process Markdown `<pre><code>` blocks.
-	#
 		$text = preg_replace_callback('{
 				(?:\n\n|\A\n?)
 				(	            # $1 = the code block -- one or more lines, starting with a space/tab
@@ -1020,54 +1201,88 @@ class Markdown implements MarkdownInterface {
 
 		return $text;
 	}
+
+	/**
+	 * Code block parsing callback
+	 * @param  array $matches
+	 * @return string
+	 */
 	protected function _doCodeBlocks_callback($matches) {
 		$codeblock = $matches[1];
 
 		$codeblock = $this->outdent($codeblock);
-		$codeblock = htmlspecialchars($codeblock, ENT_NOQUOTES);
+		if ($this->code_block_content_func) {
+			$codeblock = call_user_func($this->code_block_content_func, $codeblock, "");
+		} else {
+			$codeblock = htmlspecialchars($codeblock, ENT_NOQUOTES);
+		}
 
 		# trim leading newlines and trailing newlines
 		$codeblock = preg_replace('/\A\n+|\n+\z/', '', $codeblock);
 
 		$codeblock = "<pre><code>$codeblock\n</code></pre>";
-		return "\n\n".$this->hashBlock($codeblock)."\n\n";
+		return "\n\n" . $this->hashBlock($codeblock) . "\n\n";
 	}
 
-
+	/**
+	 * Create a code span markup for $code. Called from handleSpanToken.
+	 * @param  string $code
+	 * @return string
+	 */
 	protected function makeCodeSpan($code) {
-	#
-	# Create a code span markup for $code. Called from handleSpanToken.
-	#
-		$code = htmlspecialchars(trim($code), ENT_NOQUOTES);
+		if ($this->code_span_content_func) {
+			$code = call_user_func($this->code_span_content_func, $code);
+		} else {
+			$code = htmlspecialchars(trim($code), ENT_NOQUOTES);
+		}
 		return $this->hashPart("<code>$code</code>");
 	}
 
-
+	/**
+	 * Define the emphasis operators with their regex matches
+	 * @var array
+	 */
 	protected $em_relist = array(
 		''  => '(?:(?<!\*)\*(?!\*)|(?<!_)_(?!_))(?![\.,:;]?\s)',
 		'*' => '(?<![\s*])\*(?!\*)',
 		'_' => '(?<![\s_])_(?!_)',
-		);
+	);
+
+	/**
+	 * Define the strong operators with their regex matches
+	 * @var array
+	 */
 	protected $strong_relist = array(
 		''   => '(?:(?<!\*)\*\*(?!\*)|(?<!_)__(?!_))(?![\.,:;]?\s)',
 		'**' => '(?<![\s*])\*\*(?!\*)',
 		'__' => '(?<![\s_])__(?!_)',
-		);
+	);
+
+	/**
+	 * Define the emphasis + strong operators with their regex matches
+	 * @var array
+	 */
 	protected $em_strong_relist = array(
 		''    => '(?:(?<!\*)\*\*\*(?!\*)|(?<!_)___(?!_))(?![\.,:;]?\s)',
 		'***' => '(?<![\s*])\*\*\*(?!\*)',
 		'___' => '(?<![\s_])___(?!_)',
-		);
+	);
+
+	/**
+	 * Container for prepared regular expressions
+	 * @var array
+	 */
 	protected $em_strong_prepared_relist;
 	
+	/**
+	 * Prepare regular expressions for searching emphasis tokens in any
+	 * context.
+	 * @return void
+	 */
 	protected function prepareItalicsAndBold() {
-	#
-	# Prepare regular expressions for searching emphasis tokens in any
-	# context.
-	#
 		foreach ($this->em_relist as $em => $em_re) {
 			foreach ($this->strong_relist as $strong => $strong_re) {
-				# Construct list of allowed token expressions.
+				// Construct list of allowed token expressions.
 				$token_relist = array();
 				if (isset($this->em_strong_relist["$em$strong"])) {
 					$token_relist[] = $this->em_strong_relist["$em$strong"];
@@ -1075,13 +1290,18 @@ class Markdown implements MarkdownInterface {
 				$token_relist[] = $em_re;
 				$token_relist[] = $strong_re;
 				
-				# Construct master expression from list.
-				$token_re = '{('. implode('|', $token_relist) .')}';
+				// Construct master expression from list.
+				$token_re = '{(' . implode('|', $token_relist) . ')}';
 				$this->em_strong_prepared_relist["$em$strong"] = $token_re;
 			}
 		}
 	}
-	
+
+	/**
+	 * Convert Markdown italics (emphasis) and bold (strong) to HTML
+	 * @param  string $text
+	 * @return string
+	 */
 	protected function doItalicsAndBold($text) {
 		$token_stack = array('');
 		$text_stack = array('');
@@ -1090,24 +1310,20 @@ class Markdown implements MarkdownInterface {
 		$tree_char_em = false;
 		
 		while (1) {
-			#
-			# Get prepared regular expression for seraching emphasis tokens
-			# in current context.
-			#
+			// Get prepared regular expression for seraching emphasis tokens
+			// in current context.
 			$token_re = $this->em_strong_prepared_relist["$em$strong"];
 			
-			#
-			# Each loop iteration search for the next emphasis token. 
-			# Each token is then passed to handleSpanToken.
-			#
+			// Each loop iteration search for the next emphasis token. 
+			// Each token is then passed to handleSpanToken.
 			$parts = preg_split($token_re, $text, 2, PREG_SPLIT_DELIM_CAPTURE);
 			$text_stack[0] .= $parts[0];
 			$token =& $parts[1];
 			$text =& $parts[2];
 			
 			if (empty($token)) {
-				# Reached end of text span: empty stack without emitting.
-				# any more emphasis.
+				// Reached end of text span: empty stack without emitting.
+				// any more emphasis.
 				while ($token_stack[0]) {
 					$text_stack[1] .= array_shift($token_stack);
 					$text_stack[0] .= array_shift($text_stack);
@@ -1117,9 +1333,9 @@ class Markdown implements MarkdownInterface {
 			
 			$token_len = strlen($token);
 			if ($tree_char_em) {
-				# Reached closing marker while inside a three-char emphasis.
+				// Reached closing marker while inside a three-char emphasis.
 				if ($token_len == 3) {
-					# Three-char closing marker, close em and strong.
+					// Three-char closing marker, close em and strong.
 					array_shift($token_stack);
 					$span = array_shift($text_stack);
 					$span = $this->runSpanGamut($span);
@@ -1128,21 +1344,21 @@ class Markdown implements MarkdownInterface {
 					$em = '';
 					$strong = '';
 				} else {
-					# Other closing marker: close one em or strong and
-					# change current token state to match the other
+					// Other closing marker: close one em or strong and
+					// change current token state to match the other
 					$token_stack[0] = str_repeat($token{0}, 3-$token_len);
 					$tag = $token_len == 2 ? "strong" : "em";
 					$span = $text_stack[0];
 					$span = $this->runSpanGamut($span);
 					$span = "<$tag>$span</$tag>";
 					$text_stack[0] = $this->hashPart($span);
-					$$tag = ''; # $$tag stands for $em or $strong
+					$$tag = ''; // $$tag stands for $em or $strong
 				}
 				$tree_char_em = false;
 			} else if ($token_len == 3) {
 				if ($em) {
-					# Reached closing marker for both em and strong.
-					# Closing strong marker:
+					// Reached closing marker for both em and strong.
+					// Closing strong marker:
 					for ($i = 0; $i < 2; ++$i) {
 						$shifted_token = array_shift($token_stack);
 						$tag = strlen($shifted_token) == 2 ? "strong" : "em";
@@ -1150,11 +1366,11 @@ class Markdown implements MarkdownInterface {
 						$span = $this->runSpanGamut($span);
 						$span = "<$tag>$span</$tag>";
 						$text_stack[0] .= $this->hashPart($span);
-						$$tag = ''; # $$tag stands for $em or $strong
+						$$tag = ''; // $$tag stands for $em or $strong
 					}
 				} else {
-					# Reached opening three-char emphasis marker. Push on token 
-					# stack; will be handled by the special condition above.
+					// Reached opening three-char emphasis marker. Push on token 
+					// stack; will be handled by the special condition above.
 					$em = $token{0};
 					$strong = "$em$em";
 					array_unshift($token_stack, $token);
@@ -1163,12 +1379,12 @@ class Markdown implements MarkdownInterface {
 				}
 			} else if ($token_len == 2) {
 				if ($strong) {
-					# Unwind any dangling emphasis marker:
+					// Unwind any dangling emphasis marker:
 					if (strlen($token_stack[0]) == 1) {
 						$text_stack[1] .= array_shift($token_stack);
 						$text_stack[0] .= array_shift($text_stack);
 					}
-					# Closing strong marker:
+					// Closing strong marker:
 					array_shift($token_stack);
 					$span = array_shift($text_stack);
 					$span = $this->runSpanGamut($span);
@@ -1181,10 +1397,10 @@ class Markdown implements MarkdownInterface {
 					$strong = $token;
 				}
 			} else {
-				# Here $token_len == 1
+				// Here $token_len == 1
 				if ($em) {
 					if (strlen($token_stack[0]) == 1) {
-						# Closing emphasis marker:
+						// Closing emphasis marker:
 						array_shift($token_stack);
 						$span = array_shift($text_stack);
 						$span = $this->runSpanGamut($span);
@@ -1204,7 +1420,11 @@ class Markdown implements MarkdownInterface {
 		return $text_stack[0];
 	}
 
-
+	/**
+	 * Parse Markdown blockquotes to HTML
+	 * @param  string $text
+	 * @return string
+	 */
 	protected function doBlockQuotes($text) {
 		$text = preg_replace_callback('/
 			  (								# Wrap whole match in $1
@@ -1220,51 +1440,64 @@ class Markdown implements MarkdownInterface {
 
 		return $text;
 	}
+
+	/**
+	 * Blockquote parsing callback
+	 * @param  array $matches
+	 * @return string
+	 */
 	protected function _doBlockQuotes_callback($matches) {
 		$bq = $matches[1];
-		# trim one level of quoting - trim whitespace-only lines
+		// trim one level of quoting - trim whitespace-only lines
 		$bq = preg_replace('/^[ ]*>[ ]?|^[ ]+$/m', '', $bq);
-		$bq = $this->runBlockGamut($bq);		# recurse
+		$bq = $this->runBlockGamut($bq); // recurse
 
 		$bq = preg_replace('/^/m', "  ", $bq);
-		# These leading spaces cause problem with <pre> content, 
-		# so we need to fix that:
+		// These leading spaces cause problem with <pre> content, 
+		// so we need to fix that:
 		$bq = preg_replace_callback('{(\s*<pre>.+?</pre>)}sx', 
 			array($this, '_doBlockQuotes_callback2'), $bq);
 
-		return "\n". $this->hashBlock("<blockquote>\n$bq\n</blockquote>")."\n\n";
+		return "\n" . $this->hashBlock("<blockquote>\n$bq\n</blockquote>") . "\n\n";
 	}
+
+	/**
+	 * Blockquote parsing callback
+	 * @param  array $matches
+	 * @return string
+	 */
 	protected function _doBlockQuotes_callback2($matches) {
 		$pre = $matches[1];
 		$pre = preg_replace('/^  /m', '', $pre);
 		return $pre;
 	}
 
-
-	protected function formParagraphs($text) {
-	#
-	#	Params:
-	#		$text - string to process with html <p> tags
-	#
-		# Strip leading and trailing lines:
+	/**
+	 * Parse paragraphs
+	 *
+	 * @param  string $text String to process in paragraphs
+	 * @param  boolean $wrap_in_p Whether paragraphs should be wrapped in <p> tags
+	 * @return string
+	 */
+	protected function formParagraphs($text, $wrap_in_p = true) {
+		// Strip leading and trailing lines:
 		$text = preg_replace('/\A\n+|\n+\z/', '', $text);
 
 		$grafs = preg_split('/\n{2,}/', $text, -1, PREG_SPLIT_NO_EMPTY);
 
-		#
-		# Wrap <p> tags and unhashify HTML blocks
-		#
+		// Wrap <p> tags and unhashify HTML blocks
 		foreach ($grafs as $key => $value) {
 			if (!preg_match('/^B\x1A[0-9]+B$/', $value)) {
-				# Is a paragraph.
+				// Is a paragraph.
 				$value = $this->runSpanGamut($value);
-				$value = preg_replace('/^([ ]*)/', "<p>", $value);
-				$value .= "</p>";
+				if ($wrap_in_p) {
+					$value = preg_replace('/^([ ]*)/', "<p>", $value);
+					$value .= "</p>";
+				}
 				$grafs[$key] = $this->unhash($value);
-			}
-			else {
-				# Is a block.
-				# Modify elements of @grafs in-place...
+			} else {
+				// Is a block.
+				// Modify elements of @grafs in-place...
 				$graf = $value;
 				$block = $this->html_hashes[$graf];
 				$graf = $block;
@@ -1289,11 +1522,11 @@ class Markdown implements MarkdownInterface {
 //				{
 //					list(, $div_open, , $div_content, $div_close) = $matches;
 //
-//					# We can't call Markdown(), because that resets the hash;
-//					# that initialization code should be pulled into its own sub, though.
+//					// We can't call Markdown(), because that resets the hash;
+//					// that initialization code should be pulled into its own sub, though.
 //					$div_content = $this->hashHTMLBlocks($div_content);
 //					
-//					# Run document gamut methods on the content.
+//					// Run document gamut methods on the content.
 //					foreach ($this->document_gamut as $method => $priority) {
 //						$div_content = $this->$method($div_content);
 //					}
@@ -1310,37 +1543,39 @@ class Markdown implements MarkdownInterface {
 		return implode("\n\n", $grafs);
 	}
 
-
+	/**
+	 * Encode text for a double-quoted HTML attribute. This function
+	 * is *not* suitable for attributes enclosed in single quotes.
+	 * @param  string $text
+	 * @return string
+	 */
 	protected function encodeAttribute($text) {
-	#
-	# Encode text for a double-quoted HTML attribute. This function
-	# is *not* suitable for attributes enclosed in single quotes.
-	#
 		$text = $this->encodeAmpsAndAngles($text);
 		$text = str_replace('"', '&quot;', $text);
 		return $text;
 	}
 
-
+	/**
+	 * Encode text for a double-quoted HTML attribute containing a URL,
+	 * applying the URL filter if set. Also generates the textual
+	 * representation for the URL (removing mailto: or tel:) storing it in $text.
+	 * This function is *not* suitable for attributes enclosed in single quotes.
+	 *
+	 * @param  string $url
+	 * @param  string &$text Passed by reference
+	 * @return string        URL
+	 */
 	protected function encodeURLAttribute($url, &$text = null) {
-	#
-	# Encode text for a double-quoted HTML attribute containing a URL,
-	# applying the URL filter if set. Also generates the textual
-	# representation for the URL (removing mailto: or tel:) storing it in $text.
-	# This function is *not* suitable for attributes enclosed in single quotes.
-	#
-		if ($this->url_filter_func)
+		if ($this->url_filter_func) {
 			$url = call_user_func($this->url_filter_func, $url);
+		}
 
-		if (preg_match('{^mailto:}i', $url))
+		if (preg_match('{^mailto:}i', $url)) {
 			$url = $this->encodeEntityObfuscatedAttribute($url, $text, 7);
-		else if (preg_match('{^tel:}i', $url))
-		{
+		} else if (preg_match('{^tel:}i', $url)) {
 			$url = $this->encodeAttribute($url);
 			$text = substr($url, 4);
-		}
-		else
-		{
+		} else {
 			$url = $this->encodeAttribute($url);
 			$text = $url;
 		}
@@ -1348,33 +1583,38 @@ class Markdown implements MarkdownInterface {
 		return $url;
 	}
 	
-	
+	/**
+	 * Smart processing for ampersands and angle brackets that need to 
+	 * be encoded. Valid character entities are left alone unless the
+	 * no-entities mode is set.
+	 * @param  string $text
+	 * @return string
+	 */
 	protected function encodeAmpsAndAngles($text) {
-	#
-	# Smart processing for ampersands and angle brackets that need to 
-	# be encoded. Valid character entities are left alone unless the
-	# no-entities mode is set.
-	#
 		if ($this->no_entities) {
 			$text = str_replace('&', '&amp;', $text);
 		} else {
-			# Ampersand-encoding based entirely on Nat Irons's Amputator
-			# MT plugin: <http://bumppo.net/projects/amputator/>
+			// Ampersand-encoding based entirely on Nat Irons's Amputator
+			// MT plugin: <http://bumppo.net/projects/amputator/>
 			$text = preg_replace('/&(?!#?[xX]?(?:[0-9a-fA-F]+|\w+);)/', 
 								'&amp;', $text);
 		}
-		# Encode remaining <'s
+		// Encode remaining <'s
 		$text = str_replace('<', '&lt;', $text);
 
 		return $text;
 	}
 
-
+	/**
+	 * Parse Markdown automatic links to anchor HTML tags
+	 * @param  string $text
+	 * @return string
+	 */
 	protected function doAutoLinks($text) {
 		$text = preg_replace_callback('{<((https?|ftp|dict|tel):[^\'">\s]+)>}i',
 			array($this, '_doAutoLinks_url_callback'), $text);
 
-		# Email addresses: <address@domain.foo>
+		// Email addresses: <address@domain.foo>
 		$text = preg_replace_callback('{
 			<
 			(?:mailto:)?
@@ -1397,11 +1637,23 @@ class Markdown implements MarkdownInterface {
 
 		return $text;
 	}
+
+	/**
+	 * Parse URL callback
+	 * @param  array $matches
+	 * @return string
+	 */
 	protected function _doAutoLinks_url_callback($matches) {
 		$url = $this->encodeURLAttribute($matches[1], $text);
 		$link = "<a href=\"$url\">$text</a>";
 		return $this->hashPart($link);
 	}
+
+	/**
+	 * Parse email address callback
+	 * @param  array $matches
+	 * @return string
+	 */
 	protected function _doAutoLinks_email_callback($matches) {
 		$addr = $matches[1];
 		$url = $this->encodeURLAttribute("mailto:$addr", $text);
@@ -1409,42 +1661,52 @@ class Markdown implements MarkdownInterface {
 		return $this->hashPart($link);
 	}
 
-
+	/**
+	 * Input: some text to obfuscate, e.g. "mailto:foo@example.com"
+	 *
+	 * Output: the same text but with most characters encoded as either a
+	 *         decimal or hex entity, in the hopes of foiling most address
+	 *         harvesting spam bots. E.g.:
+	 *
+	 *        &#109;&#x61;&#105;&#x6c;&#116;&#x6f;&#58;&#x66;o&#111;
+	 *        &#x40;&#101;&#x78;&#97;&#x6d;&#112;&#x6c;&#101;&#46;&#x63;&#111;
+	 *        &#x6d;
+	 *
+	 * Note: the additional output $tail is assigned the same value as the
+	 * ouput, minus the number of characters specified by $head_length.
+	 *
+	 * Based by a filter by Matthew Wickline, posted to BBEdit-Talk.
+	 * With some optimizations by Milian Wolff. Forced encoding of HTML
+	 * attribute special characters by Allan Odgaard.
+	 *
+	 * @param  string  $text
+	 * @param  string  &$tail
+	 * @param  integer $head_length
+	 * @return string
+	 */
 	protected function encodeEntityObfuscatedAttribute($text, &$tail = null, $head_length = 0) {
-	#
-	#	Input: some text to obfuscate, e.g. "mailto:foo@example.com"
-	#
-	#	Output: the same text but with most characters encoded as either a
-	#		decimal or hex entity, in the hopes of foiling most address
-	#		harvesting spam bots. E.g.:
-	#
-	#        &#109;&#x61;&#105;&#x6c;&#116;&#x6f;&#58;&#x66;o&#111;
-	#        &#x40;&#101;&#x78;&#97;&#x6d;&#112;&#x6c;&#101;&#46;&#x63;&#111;
-	#        &#x6d;
-	#
-	#	Note: the additional output $tail is assigned the same value as the
-	#	ouput, minus the number of characters specified by $head_length.
-	#
-	#	Based by a filter by Matthew Wickline, posted to BBEdit-Talk.
-	#   With some optimizations by Milian Wolff. Forced encoding of HTML
-	#	attribute special characters by Allan Odgaard.
-	#
-		if ($text == "") return $tail = "";
+		if ($text == "") {
+			return $tail = "";
+		}
 
 		$chars = preg_split('/(?<!^)(?!$)/', $text);
-		$seed = (int)abs(crc32($text) / strlen($text)); # Deterministic seed.
+		$seed = (int)abs(crc32($text) / strlen($text)); // Deterministic seed.
 
 		foreach ($chars as $key => $char) {
 			$ord = ord($char);
-			# Ignore non-ascii chars.
+			// Ignore non-ascii chars.
 			if ($ord < 128) {
-				$r = ($seed * (1 + $key)) % 100; # Pseudo-random function.
-				# roughly 10% raw, 45% hex, 45% dec
-				# '@' *must* be encoded. I insist.
-				# '"' and '>' have to be encoded inside the attribute
-				if ($r > 90 && strpos('@"&>', $char) === false) /* do nothing */;
-				else if ($r < 45) $chars[$key] = '&#x'.dechex($ord).';';
-				else              $chars[$key] = '&#'.$ord.';';
+				$r = ($seed * (1 + $key)) % 100; // Pseudo-random function.
+				// roughly 10% raw, 45% hex, 45% dec
+				// '@' *must* be encoded. I insist.
+				// '"' and '>' have to be encoded inside the attribute
+				if ($r > 90 && strpos('@"&>', $char) === false) {
+					/* do nothing */
+				} else if ($r < 45) {
+					$chars[$key] = '&#x'.dechex($ord).';';
+				} else {
+					$chars[$key] = '&#'.$ord.';';
+				}
 			}
 		}
 
@@ -1454,12 +1716,13 @@ class Markdown implements MarkdownInterface {
 		return $text;
 	}
 
-
+	/**
+	 * Take the string $str and parse it into tokens, hashing embeded HTML,
+	 * escaped characters and handling code spans.
+	 * @param  string $str
+	 * @return string
+	 */
 	protected function parseSpan($str) {
-	#
-	# Take the string $str and parse it into tokens, hashing embeded HTML,
-	# escaped characters and handling code spans.
-	#
 		$output = '';
 		
 		$span_re = '{
@@ -1489,42 +1752,41 @@ class Markdown implements MarkdownInterface {
 				}xs';
 
 		while (1) {
-			#
-			# Each loop iteration seach for either the next tag, the next 
-			# openning code span marker, or the next escaped character. 
-			# Each token is then passed to handleSpanToken.
-			#
+			// Each loop iteration seach for either the next tag, the next 
+			// openning code span marker, or the next escaped character. 
+			// Each token is then passed to handleSpanToken.
 			$parts = preg_split($span_re, $str, 2, PREG_SPLIT_DELIM_CAPTURE);
 			
-			# Create token from text preceding tag.
+			// Create token from text preceding tag.
 			if ($parts[0] != "") {
 				$output .= $parts[0];
 			}
 			
-			# Check if we reach the end.
+			// Check if we reach the end.
 			if (isset($parts[1])) {
 				$output .= $this->handleSpanToken($parts[1], $parts[2]);
 				$str = $parts[2];
-			}
-			else {
+			} else {
 				break;
 			}
 		}
 		
 		return $output;
 	}
-	
-	
+
+	/**
+	 * Handle $token provided by parseSpan by determining its nature and
+	 * returning the corresponding value that should replace it.
+	 * @param  string $token
+	 * @param  string &$str
+	 * @return string
+	 */
 	protected function handleSpanToken($token, &$str) {
-	#
-	# Handle $token provided by parseSpan by determining its nature and 
-	# returning the corresponding value that should replace it.
-	#
 		switch ($token{0}) {
 			case "\\":
 				return $this->hashPart("&#". ord($token{1}). ";");
 			case "`":
-				# Search for end marker in remaining text.
+				// Search for end marker in remaining text.
 				if (preg_match('/^(.*?[^`])'.preg_quote($token).'(?!`)(.*)$/sm', 
 					$str, $matches))
 				{
@@ -1532,78 +1794,103 @@ class Markdown implements MarkdownInterface {
 					$codespan = $this->makeCodeSpan($matches[1]);
 					return $this->hashPart($codespan);
 				}
-				return $token; // return as text since no ending marker found.
+				return $token; // Return as text since no ending marker found.
 			default:
 				return $this->hashPart($token);
 		}
 	}
 
-
+	/**
+	 * Remove one level of line-leading tabs or spaces
+	 * @param  string $text
+	 * @return string
+	 */
 	protected function outdent($text) {
-	#
-	# Remove one level of line-leading tabs or spaces
-	#
-		return preg_replace('/^(\t|[ ]{1,'.$this->tab_width.'})/m', '', $text);
+		return preg_replace('/^(\t|[ ]{1,' . $this->tab_width . '})/m', '', $text);
 	}
 
 
-	# String length function for detab. `_initDetab` will create a function to 
-	# hanlde UTF-8 if the default function does not exist.
+	/**
+	 * String length function for detab. `_initDetab` will create a function to
+	 * handle UTF-8 if the default function does not exist.
+	 * @var string
+	 */
 	protected $utf8_strlen = 'mb_strlen';
-	
-	protected function detab($text) {
-	#
-	# Replace tabs with the appropriate amount of space.
-	#
-		# For each line we separate the line in blocks delemited by
-		# tab characters. Then we reconstruct every line by adding the 
-		# appropriate number of space between each blocks.
-		
+
+	/**
+	 * Replace tabs with the appropriate amount of spaces.
+	 *
+	 * For each line we separate the line in blocks delemited by tab characters.
+	 * Then we reconstruct every line by adding the  appropriate number of space
+	 * between each blocks.
+	 * 
+	 * @param  string $text
+	 * @return string
+	 */
+	protected function detab($text) {	
 		$text = preg_replace_callback('/^.*\t.*$/m',
 			array($this, '_detab_callback'), $text);
 
 		return $text;
 	}
+
+	/**
+	 * Replace tabs callback
+	 * @param  string $matches
+	 * @return string
+	 */
 	protected function _detab_callback($matches) {
 		$line = $matches[0];
-		$strlen = $this->utf8_strlen; # strlen function for UTF-8.
+		$strlen = $this->utf8_strlen; // strlen function for UTF-8.
 		
-		# Split in blocks.
+		// Split in blocks.
 		$blocks = explode("\t", $line);
-		# Add each blocks to the line.
+		// Add each blocks to the line.
 		$line = $blocks[0];
-		unset($blocks[0]); # Do not add first block twice.
+		unset($blocks[0]); // Do not add first block twice.
 		foreach ($blocks as $block) {
-			# Calculate amount of space, insert spaces, insert block.
+			// Calculate amount of space, insert spaces, insert block.
 			$amount = $this->tab_width - 
 				$strlen($line, 'UTF-8') % $this->tab_width;
 			$line .= str_repeat(" ", $amount) . $block;
 		}
 		return $line;
 	}
+
+	/**
+	 * Check for the availability of the function in the `utf8_strlen` property
+	 * (initially `mb_strlen`). If the function is not available, create a 
+	 * function that will loosely count the number of UTF-8 characters with a
+	 * regular expression.
+	 * @return void
+	 */
 	protected function _initDetab() {
-	#
-	# Check for the availability of the function in the `utf8_strlen` property
-	# (initially `mb_strlen`). If the function is not available, create a 
-	# function that will loosely count the number of UTF-8 characters with a
-	# regular expression.
-	#
-		if (function_exists($this->utf8_strlen)) return;
+	
+		if (function_exists($this->utf8_strlen)) {
+			return;
+		}
+
 		$this->utf8_strlen = create_function('$text', 'return preg_match_all(
 			"/[\\\\x00-\\\\xBF]|[\\\\xC0-\\\\xFF][\\\\x80-\\\\xBF]*/", 
 			$text, $m);');
 	}
 
-
+	/**
+	 * Swap back in all the tags hashed by _HashHTMLBlocks.
+	 * @param  string $text
+	 * @return string
+	 */
 	protected function unhash($text) {
-	#
-	# Swap back in all the tags hashed by _HashHTMLBlocks.
-	#
 		return preg_replace_callback('/(.)\x1A[0-9]+\1/', 
 			array($this, '_unhash_callback'), $text);
 	}
+
+	/**
+	 * Unhashing callback
+	 * @param  array $matches
+	 * @return string
+	 */
 	protected function _unhash_callback($matches) {
 		return $this->html_hashes[$matches[0]];
 	}
-
 }

--- a/lib/Michelf/MarkdownInterface.inc.php
+++ b/lib/Michelf/MarkdownInterface.inc.php
@@ -1,9 +1,9 @@
 <?php
 
-# Use this file if you cannot use class autoloading. It will include all the
-# files needed for the MarkdownInterface interface.
-#
-# Take a look at the PSR-0-compatible class autoloading implementation
-# in the Readme.php file if you want a simple autoloader setup.
+// Use this file if you cannot use class autoloading. It will include all the
+// files needed for the MarkdownInterface interface.
+//
+// Take a look at the PSR-0-compatible class autoloading implementation
+// in the Readme.php file if you want a simple autoloader setup.
 
 require_once dirname(__FILE__) . '/MarkdownInterface.php';

--- a/lib/Michelf/MarkdownInterface.php
+++ b/lib/Michelf/MarkdownInterface.php
@@ -1,34 +1,38 @@
 <?php
-#
-# Markdown  -  A text-to-HTML conversion tool for web writers
-#
-# PHP Markdown
-# Copyright (c) 2004-2015 Michel Fortin
-# <https://michelf.ca/projects/php-markdown/>
-#
-# Original Markdown
-# Copyright (c) 2004-2006 John Gruber
-# <http://daringfireball.net/projects/markdown/>
-#
+/**
+ * Markdown  -  A text-to-HTML conversion tool for web writers
+ *
+ * @package   php-markdown
+ * @author    Michel Fortin <michel.fortin@michelf.com>
+ * @copyright 2004-2016 Michel Fortin <https://michelf.com/projects/php-markdown/>
+ * @copyright (Original Markdown) 2004-2006 John Gruber <https://daringfireball.net/projects/markdown/>
+ */
+
 namespace Michelf;
 
-
-#
-# Markdown Parser Interface
-#
-
+/**
+ * Markdown Parser Interface 
+ */
 interface MarkdownInterface {
+	/**
+	 * Initialize the parser and return the result of its transform method.
+	 * This will work fine for derived classes too.
+	 *
+	 * @api
+	 *
+	 * @param  string $text
+	 * @return string
+	 */
+	public static function defaultTransform($text);
 
-  #
-  # Initialize the parser and return the result of its transform method.
-  # This will work fine for derived classes too.
-  #
-  public static function defaultTransform($text);
-
-  #
-  # Main function. Performs some preprocessing on the input text
-  # and pass it through the document gamut.
-  #
-  public function transform($text);
-
+	/**
+	 * Main function. Performs some preprocessing on the input text
+	 * and pass it through the document gamut.
+	 *
+	 * @api
+	 *
+	 * @param  string $text
+	 * @return string
+	 */
+	public function transform($text);
 }


### PR DESCRIPTION
PHP Markdown has been upgraded to 1.7.0 and has been tested on Ubuntu, Fedora & CentOS based servers, with PHP 5 & PHP 7 on NginX.

The reason behind the upgrade is to resolve the rendering issue at the bottom of the page, in the list of implementations, whereby the last description is inside of a H2 tag, rather than in the list item. 

Please see the following screenshot.

![ogp](https://cloud.githubusercontent.com/assets/22813671/20097756/0372ff4a-a5a8-11e6-81b1-dd6c18ad4f5a.jpg)