### PR TITLE
Added OpenGraph service OpenGraph.io

### DIFF
--- a/content/index.markdown
+++ b/content/index.markdown
@@ -406,6 +406,7 @@ tools. Let the Facebook group know if you've built something awesome too!
 * [OpenGraph for Java](http://github.com/callumj/opengraph-java) - Small Java class used to represent the Open Graph protocol.
 * [RDF::RDFa::Parser](http://search.cpan.org/~tobyink/RDF-RDFa-Parser/lib/RDF/RDFa/Parser.pm) - Perl RDFa parser which understands the Open Graph protocol.
 * [Alternate WordPress OGP plugin](http://wordpress.org/plugins/wp-facebook-open-graph-protocol/) - A simple lightweight WordPress plugin which adds Open Graph metadata to WordPress powered sites.
+* [OpenGraph.io](https://www.opengraph.io/) - A REST service that parses Open Graph data or infers what it should be based on page content. 
 
 
 ---


### PR DESCRIPTION
Hi!

I added a link to an OpenGraph service that I have been improving for 3 years now.  The service reads Open Graph tags on a page and infers values of any tags that are missing.

The service is a simple REST API.  I have recently started adding client libraries ( https://github.com/primeobsession/opengraph-io ) and plan to continue adding them.

Just over 96% of the users use the free version of the service and I would love to increase the overall user base to help pay for server costs!  

Thanks!

