### PR TITLE
Issue about locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 The files used for hosting http://ogp.me/
 
 If you want to contribute, feel free to send pull requests and discuss any issues in the [Facebook Group](https://www.facebook.com/groups/opengraph/)
+
+Theog og:locale says its value should be "The locale these tags are marked up in. Of the format language_TERRITORY. Default is en_US.". But how do I know which identifier use for a language and which identifier use for a territory. Must they have all two words? I think that this specification should mention [ISO 639](https://en.wikipedia.org/wiki/ISO_639) as a reference or something similar. Otherwise, it's' impossible to know which values are correct/valid/expected.


### PR DESCRIPTION
The og:locale says its value should be "The locale these tags are marked up in. Of the format language_TERRITORY. Default is en_US.". But how do I know which identifier use for a language and which identifier use for a territory? Must they have all two characters? I think that this specification should mention [ISO 639](https://en.wikipedia.org/wiki/ISO_639) as a reference or something similar. Otherwise, it's' impossible to know which values are correct/valid/expected.