### PR TITLE
Add `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/codeofconduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to Open Graph Protocol
+We want to make contributing to this project as easy and transparent as
+possible.
+
+## Code of Conduct
+The code of conduct is described in [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
+## Pull Requests
+We actively welcome your pull requests.
+
+1. Fork the repo and create your branch from `master`.
+2. If you've added code that should be tested, add tests.
+3. If you've changed APIs, update the documentation.
+4. Ensure the test suite passes.
+5. Make sure your code lints.
+6. If you haven't already, complete the Contributor License Agreement ("CLA").
+
+## Contributor License Agreement ("CLA")
+In order to accept your pull request, we need you to submit a CLA. You only need
+to do this once to work on any of Facebook's open source projects.
+
+Complete your CLA here: <https://code.facebook.com/cla>
+
+## Issues
+We use GitHub issues to track public bugs. Please ensure your description is
+clear and has sufficient instructions to be able to reproduce the issue.
+
+Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe
+disclosure of security bugs. In those cases, please go through the process
+outlined on that page and do not file a public issue.
+
+## License
+By contributing to Open Graph Protocol, you agree that your contributions will be licensed
+under the LICENSE file in the root directory of this source tree.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 The files used for hosting http://ogp.me/
 
 If you want to contribute, feel free to send pull requests and discuss any issues in the [Facebook Group](https://www.facebook.com/groups/opengraph/)
+
+You can also find more details about contributing in the [`CONTRIBUTING.md`](CONTRIBUTING.md).


### PR DESCRIPTION
To support a healthy, welcoming Open Source Community, it makes sense to add a `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md`, even though it looks like this project has not been active for some years.

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow, to promote a welcoming and safe open source community.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will improve [the Open Graph Protocol community profile](https://github.com/facebook/open-graph-protocol/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1310" alt="screen shot 2017-11-26 at 4 39 54 pm" src="https://user-images.githubusercontent.com/1114467/33246393-c4a4e234-d2c8-11e7-8e4b-ae1a0a4a1165.png">
<img width="1292" alt="screen shot 2017-11-26 at 4 40 05 pm" src="https://user-images.githubusercontent.com/1114467/33246394-c4c3c7bc-d2c8-11e7-8bb1-6516184f5c87.png">
<img width="1313" alt="screen shot 2017-11-26 at 4 40 32 pm" src="https://user-images.githubusercontent.com/1114467/33246395-c4e19be8-d2c8-11e7-9d28-71ae507311a7.png">

**issue:**
internal task t23481323