### PR TITLE
Update to links

### DIFF
--- a/content/index.markdown
+++ b/content/index.markdown
@@ -1,6 +1,6 @@
 ## <a id="intro" href="#intro">Introduction</a>
 
-The [Open Graph protocol](http://ogp.me/) enables any web page to become a
+The [Open Graph protocol](https://ogp.me/) enables any web page to become a
 rich object in a social graph. For instance, this is used on Facebook to allow
 any web page to have the same functionality as any other object on Facebook.
 
@@ -11,7 +11,7 @@ builds on these existing technologies and gives developers one thing to
 implement. Developer simplicity is a key goal of the Open Graph protocol which
 has informed many of
 [the technical design decisions](
-http://www.scribd.com/doc/30715288/The-Open-Graph-Protocol-Design-Decisions).
+https://www.scribd.com/doc/30715288/The-Open-Graph-Protocol-Design-Decisions).
 
 
 ---
@@ -80,8 +80,8 @@ For example (line-break solely for display purposes):
     <meta property="og:site_name" content="IMDb" />
     <meta property="og:video" content="http://example.com/bond/trailer.swf" />
 
-The RDF schema (in [Turtle](http://en.wikipedia.org/wiki/Turtle_(syntax))) 
-can be found at [ogp.me/ns](http://ogp.me/ns/ogp.me.ttl).
+The RDF schema (in [Turtle](https://en.wikipedia.org/wiki/Turtle_(syntax))) 
+can be found at [ogp.me/ns](https://ogp.me/ns/ogp.me.ttl).
 
 ---
 ## <a id="structured" href="#structured">Structured Properties</a>
@@ -96,7 +96,7 @@ The `og:image` property has some optional structured properties:
  * `og:image:secure_url` - An alternate url to use if the webpage requires
     HTTPS.
  * `og:image:type` - A [MIME type](
-    http://en.wikipedia.org/wiki/Internet_media_type) for this image.
+    https://en.wikipedia.org/wiki/Internet_media_type) for this image.
  * `og:image:width` - The number of pixels wide.
  * `og:image:height` - The number of pixels high.
 
@@ -159,7 +159,7 @@ specify its type. This is done using the `og:type` property:
 
 When the community agrees on the schema for a type, it is added to the list
 of global types. All other objects in the type system are
-[CURIEs](http://en.wikipedia.org/wiki/CURIE) of the form
+[CURIEs](https://en.wikipedia.org/wiki/CURIE) of the form
 
     <head prefix="my_namespace: http://example.com/ns#">
     <meta property="og:type" content="my_namespace:my_type" />
@@ -378,15 +378,15 @@ The following types are used when defining attributes in Open Graph protocol.
 
 You can discuss the Open Graph Protocol in
 [the Facebook group](
-https://www.facebook.com/groups/opengraph/) or on 
-[the developer mailing list](
-http://groups.google.com/group/open-graph-protocol).
+https://www.facebook.com/groups/opengraph/) or contribute on 
+[Github](
+https://github.com/facebook/open-graph-protocol/).
 It is currently being consumed by Facebook
 ([see their documentation](
-http://developers.facebook.com/docs/opengraph/)), Google ([see their documentation](
-https://developers.google.com/+/web/snippet/)), and
+https://developers.facebook.com/docs/sharing/opengraph)), Twitter ([see their documentation](
+https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started#twitter-cards-and-open-graph)), Yandex ([see their documentation](https://yandex.com/support/webmaster/open-graph/intro-open-graph.html)), LinkedIn ([see their documentation](https://www.linkedin.com/help/linkedin/answer/46687/making-your-website-shareable-on-linkedin?lang=en)), Pinterest ([see their documentation](https://developers.pinterest.com/docs/rich-pins/articles/)) and
 [mixi](
-http://developer.mixi.co.jp/en/connect/mixi_plugin/mixi_check/spec_mixi_check/).
+https://developer.mixi.co.jp/en/connect/mixi_plugin/mixi_check/spec_mixi_check/).
 It is being published by IMDb, Microsoft, NHL, Posterous, Rotten Tomatoes,
 TIME, Yelp, and many many others.
 
@@ -396,16 +396,16 @@ TIME, Yelp, and many many others.
 The open source community has developed a number of parsers and publishing
 tools. Let the Facebook group know if you've built something awesome too!
 
-* [Facebook Object Debugger](http://developers.facebook.com/tools/debug/) - Facebook's official parser and debugger.
-* [Google Rich Snippets Testing Tool](http://www.google.com/webmasters/tools/richsnippets) - Open Graph protocol support in specific verticals and Search Engines.
+* [Facebook Object Debugger](https://developers.facebook.com/tools/debug/) - Facebook's official parser and debugger.
+* [Google Rich Snippets Testing Tool](https://www.google.com/webmasters/tools/richsnippets) - Open Graph protocol support in specific verticals and Search Engines.
 * [PHP Validator and Markup Generator](https://github.com/niallkennedy/open-graph-protocol-tools) - OGP 2011 input validator and markup generator in PHP5 objects.
-* [PHP Consumer](http://github.com/scottmac/opengraph) - A small library for accessing of Open Graph Protocol data in PHP.
+* [PHP Consumer](https://github.com/scottmac/opengraph) - A small library for accessing of Open Graph Protocol data in PHP.
 * [OpenGraphNode in PHP](http://buzzword.org.uk/2010/opengraph/#php) - A simple parser for PHP.
-* [PyOpenGraph](http://pypi.python.org/pypi/PyOpenGraph) - A library written in Python for parsing Open Graph protocol information from web sites.
-* [OpenGraph Ruby](http://github.com/intridea/opengraph) - Ruby Gem which parses web pages and extracts Open Graph protocol markup.
-* [OpenGraph for Java](http://github.com/callumj/opengraph-java) - Small Java class used to represent the Open Graph protocol.
-* [RDF::RDFa::Parser](http://search.cpan.org/~tobyink/RDF-RDFa-Parser/lib/RDF/RDFa/Parser.pm) - Perl RDFa parser which understands the Open Graph protocol.
-* [Alternate WordPress OGP plugin](http://wordpress.org/plugins/wp-facebook-open-graph-protocol/) - A simple lightweight WordPress plugin which adds Open Graph metadata to WordPress powered sites.
+* [PyOpenGraph](https://pypi.python.org/pypi/PyOpenGraph) - A library written in Python for parsing Open Graph protocol information from web sites.
+* [OpenGraph Ruby](https://github.com/intridea/opengraph) - Ruby Gem which parses web pages and extracts Open Graph protocol markup.
+* [OpenGraph for Java](https://github.com/callumj/opengraph-java) - Small Java class used to represent the Open Graph protocol.
+* [RDF::RDFa::Parser](https://search.cpan.org/~tobyink/RDF-RDFa-Parser/lib/RDF/RDFa/Parser.pm) - Perl RDFa parser which understands the Open Graph protocol.
+* [Alternate WordPress OGP plugin](https://wordpress.org/plugins/wp-facebook-open-graph-protocol/) - A simple lightweight WordPress plugin which adds Open Graph metadata to WordPress powered sites.
 
 
 ---


### PR DESCRIPTION
- Add `https://` where possible (of course excluding namespace URIs)
- Remove the link to the OGP forum page on Google Groups as it is doesn't appear to exist anymore (https://groups.google.com/group/open-graph-protocol)
- Add a few more consumers of OGP such as Twitter, Pinterest, Yandex and LinkedIn, and the respective documentation links, as it may be helpful for web developers. Also remove the link to the Google+ documentation as it no longer exists (https://developers.google.com/+/web/snippet/).