### PR TITLE
Fix most basic html errors in  index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head prefix="og: https://ogp.me/ns#">
     <meta charset="utf-8">
     <title>The Open Graph protocol</title>
@@ -301,27 +301,27 @@ Any non-marked up webpage should be treated as <code>og:type</code> website.</p>
 </tr>
 
 <tr>
-  <td><a name="bool" href="#bool">Boolean</td>
+  <td><a name="bool" href="#bool">Boolean</a></td>
   <td>A Boolean represents a true or false value</td>
   <td>true, false, 1, 0</td>
 </tr>
 
 <tr>
-  <td><a name="datetime" href="#datetime">DateTime</td>
+  <td><a name="datetime" href="#datetime">DateTime</a></td>
   <td>A DateTime represents a temporal value composed of a date
     (year, month, day) and an optional time component (hours, minutes)</td>
   <td><a href="https://en.wikipedia.org/wiki/ISO_8601">ISO 8601</a></td>
 </tr>
 
 <tr>
-  <td><a name="enum" href="#enum">Enum</td>
+  <td><a name="enum" href="#enum">Enum</a></td>
   <td>A type consisting of bounded set of constant string values 
   (enumeration members).
   <td>A string value that is a member of the enumeration</td>
 </tr>
 
 <tr>
-  <td><a name="float" href="#float">Float</td>
+  <td><a name="float" href="#float">Float</a></td>
   <td>A 64-bit signed floating point number</td>
   <td>All literals that conform to the following formats:<br><br>
 1.234<br>
@@ -333,7 +333,7 @@ Any non-marked up webpage should be treated as <code>og:type</code> website.</p>
 </tr>
 
 <tr>
-  <td><a name="integer" href="#integer">Integer</td>
+  <td><a name="integer" href="#integer">Integer</a></td>
   <td>A 32-bit signed integer. In many languages integers over 32-bits become 
     floats, so we limit Open Graph protocol for easy multi-language use.</td>
   <td>All literals that conform to the following formats:<br><br>
@@ -343,13 +343,13 @@ Any non-marked up webpage should be treated as <code>og:type</code> website.</p>
 </tr>
 
 <tr>
-  <td><a name="string" href="#string">String</td>
+  <td><a name="string" href="#string">String</a></td>
   <td>A sequence of Unicode characters</td>
   <td>All literals composed of Unicode characters with no escape characters</td>
 </tr>
 
 <tr>
-  <td><a name="url" href="#url">URL</td>
+  <td><a name="url" href="#url">URL</a></td>
   <td>A sequence of Unicode characters that identify an Internet resource.
   <td>All valid URLs that utilize the https:// or https:// protocols</td>
 </tr>
@@ -387,6 +387,5 @@ A simple lightweight WordPress plugin which adds Open Graph metadata to WordPres
       <p>The Open Graph protocol was originally created at Facebook and is inspired by <a href="https://en.wikipedia.org/wiki/Dublin_Core">Dublin Core</a>, <a href="https://googlewebmastercentral.blogspot.com/2009/02/specify-your-canonical.html">link-rel canonical</a>, <a href="https://microformats.org/">Microformats</a>, and <a href="https://en.wikipedia.org/wiki/RDFa">RDFa</a>. The specification described on this page is available under the <a href="https://openwebfoundation.org/legal/the-0-9-agreements---necessary-claims">Open Web Foundation Agreement, Version 0.9</a>. This website is <a href="https://github.com/facebook/open-graph-protocol">Open Source</a>. </p>
     </div>
     </div>
-</script>
   </body>
 </html>


### PR DESCRIPTION
As [validator](https://validator.w3.org/nu/?doc=https%3A%2F%2Fogp.me%2F) suggests, some of the most obvious tagging errors fixed.

I didn't touch harmless stuff like `<hr />` or those requiring CSS update, stuff like `name` on `a` instead of `id` or obsolete syntax (like `width` on `th`).