### PR TITLE
Update content sources for current state

### DIFF
--- a/content/index.markdown
+++ b/content/index.markdown
@@ -99,6 +99,7 @@ The `og:image` property has some optional structured properties:
     http://en.wikipedia.org/wiki/Internet_media_type) for this image.
  * `og:image:width` - The number of pixels wide.
  * `og:image:height` - The number of pixels high.
+ * `og:image:alt` - A description of what is in the image (not a caption). If the page specifies an og:image it should specify `og:image:alt`.
 
 A full image example:
 
@@ -107,6 +108,7 @@ A full image example:
     <meta property="og:image:type" content="image/jpeg" />
     <meta property="og:image:width" content="400" />
     <meta property="og:image:height" content="300" />
+    <meta property="og:image:alt" content="A shiny red apple with a bite taken out" />
 
 The `og:video` tag has the identical tags as `og:image`. Here is an example:
 

--- a/content/index.markdown
+++ b/content/index.markdown
@@ -1,6 +1,6 @@
 ## <a id="intro" href="#intro">Introduction</a>
 
-The [Open Graph protocol](http://ogp.me/) enables any web page to become a
+The [Open Graph protocol](https://ogp.me/) enables any web page to become a
 rich object in a social graph. For instance, this is used on Facebook to allow
 any web page to have the same functionality as any other object on Facebook.
 
@@ -11,7 +11,7 @@ builds on these existing technologies and gives developers one thing to
 implement. Developer simplicity is a key goal of the Open Graph protocol which
 has informed many of
 [the technical design decisions](
-http://www.scribd.com/doc/30715288/The-Open-Graph-Protocol-Design-Decisions).
+https://www.scribd.com/doc/30715288/The-Open-Graph-Protocol-Design-Decisions).
 
 
 ---
@@ -19,7 +19,7 @@ http://www.scribd.com/doc/30715288/The-Open-Graph-Protocol-Design-Decisions).
 
 To turn your web pages into graph objects, you need to add basic metadata to
 your page. We've based the initial version of the protocol on
-[RDFa](http://en.wikipedia.org/wiki/RDFa) which means that you'll place
+[RDFa](https://en.wikipedia.org/wiki/RDFa) which means that you'll place
 additional `<meta>` tags in the `<head>` of your web page. The four required
 properties for every page are:
 
@@ -30,18 +30,18 @@ properties for every page are:
  * `og:image` - An image URL which should represent your object within the
    graph.
  * `og:url` - The canonical URL of your object that will be used as its
-   permanent ID in the graph, e.g., "http://www.imdb.com/title/tt0117500/".
+   permanent ID in the graph, e.g., "https://www.imdb.com/title/tt0117500/".
 
 As an example, the following is the Open Graph protocol markup for [The Rock on
-IMDB](http://www.imdb.com/title/tt0117500/):
+IMDB](https://www.imdb.com/title/tt0117500/):
 
-    <html prefix="og: http://ogp.me/ns#">
+    <html prefix="og: https://ogp.me/ns#">
     <head>
     <title>The Rock (1996)</title>
     <meta property="og:title" content="The Rock" />
     <meta property="og:type" content="video.movie" />
-    <meta property="og:url" content="http://www.imdb.com/title/tt0117500/" />
-    <meta property="og:image" content="http://ia.media-imdb.com/images/rock.jpg" />
+    <meta property="og:url" content="https://www.imdb.com/title/tt0117500/" />
+    <meta property="og:image" content="https://ia.media-imdb.com/images/rock.jpg" />
     ...
     </head>
     ...
@@ -69,7 +69,7 @@ recommended:
 
 For example (line-break solely for display purposes):
 
-    <meta property="og:audio" content="http://example.com/bond/theme.mp3" />
+    <meta property="og:audio" content="https://example.com/bond/theme.mp3" />
     <meta property="og:description" 
       content="Sean Connery found fame and fortune as the
                suave, sophisticated British agent, James Bond." />
@@ -78,10 +78,10 @@ For example (line-break solely for display purposes):
     <meta property="og:locale:alternate" content="fr_FR" />
     <meta property="og:locale:alternate" content="es_ES" />
     <meta property="og:site_name" content="IMDb" />
-    <meta property="og:video" content="http://example.com/bond/trailer.swf" />
+    <meta property="og:video" content="https://example.com/bond/trailer.swf" />
 
-The RDF schema (in [Turtle](http://en.wikipedia.org/wiki/Turtle_(syntax))) 
-can be found at [ogp.me/ns](http://ogp.me/ns/ogp.me.ttl).
+The RDF schema (in [Turtle](https://en.wikipedia.org/wiki/Turtle_(syntax))) 
+can be found at [ogp.me/ns](https://ogp.me/ns/ogp.me.ttl).
 
 ---
 ## <a id="structured" href="#structured">Structured Properties</a>
@@ -96,7 +96,7 @@ The `og:image` property has some optional structured properties:
  * `og:image:secure_url` - An alternate url to use if the webpage requires
     HTTPS.
  * `og:image:type` - A [MIME type](
-    http://en.wikipedia.org/wiki/Internet_media_type) for this image.
+    https://en.wikipedia.org/wiki/Internet_media_type) for this image.
  * `og:image:width` - The number of pixels wide.
  * `og:image:height` - The number of pixels high.
  * `og:image:alt` - A description of what is in the image (not a caption). If the page specifies an og:image it should specify `og:image:alt`.
@@ -132,8 +132,8 @@ If a tag can have multiple values, just put multiple versions of the same
 `<meta>` tag on your page. The first tag (from top to bottom) is given
 preference during conflicts.
 
-    <meta property="og:image" content="http://example.com/rock.jpg" />
-    <meta property="og:image" content="http://example.com/rock2.jpg" />
+    <meta property="og:image" content="https://example.com/rock.jpg" />
+    <meta property="og:image" content="https://example.com/rock2.jpg" />
 
 Put structured properties after you declare their root tag. Whenever
 another root element is parsed, that structured property
@@ -141,11 +141,11 @@ is considered to be done and another one is started.
 
 For example:
 
-    <meta property="og:image" content="http://example.com/rock.jpg" />
+    <meta property="og:image" content="https://example.com/rock.jpg" />
     <meta property="og:image:width" content="300" />
     <meta property="og:image:height" content="300" />
-    <meta property="og:image" content="http://example.com/rock2.jpg" />
-    <meta property="og:image" content="http://example.com/rock3.jpg" />
+    <meta property="og:image" content="https://example.com/rock2.jpg" />
+    <meta property="og:image" content="https://example.com/rock3.jpg" />
     <meta property="og:image:height" content="1000" />
 
 means there are 3 images on this page, the first image is `300x300`, the middle
@@ -161,9 +161,9 @@ specify its type. This is done using the `og:type` property:
 
 When the community agrees on the schema for a type, it is added to the list
 of global types. All other objects in the type system are
-[CURIEs](http://en.wikipedia.org/wiki/CURIE) of the form
+[CURIEs](https://en.wikipedia.org/wiki/CURIE) of the form
 
-    <head prefix="my_namespace: http://example.com/ns#">
+    <head prefix="my_namespace: https://example.com/ns#">
     <meta property="og:type" content="my_namespace:my_type" />
 
 The global types are grouped into verticals. Each vertical has its
@@ -176,7 +176,7 @@ have colons in them.
 
 ### <a id="type_music" href="#type_music">Music</a>
 
-* Namespace URI: [`http://ogp.me/ns/music#`](http://ogp.me/ns/music)
+* Namespace URI: [`https://ogp.me/ns/music#`](https://ogp.me/ns/music)
 
 `og:type` values:
 
@@ -219,7 +219,7 @@ have colons in them.
 
 ### <a id="type_video" href="#type_video">Video</a>
 
-* Namespace URI: [`http://ogp.me/ns/video#`](http://ogp.me/ns/video)
+* Namespace URI: [`https://ogp.me/ns/video#`](https://ogp.me/ns/video)
 
 `og:type` values:
 
@@ -270,7 +270,7 @@ yet are broadly used and agreed upon.
 
 `og:type` values:
 
-<a name="type_article" href="#type_article">`article`</a> - Namespace URI: [`http://ogp.me/ns/article#`](http://ogp.me/ns/article)
+<a name="type_article" href="#type_article">`article`</a> - Namespace URI: [`https://ogp.me/ns/article#`](https://ogp.me/ns/article)
 
 * `article:published_time` - [datetime](#datetime) - 
   When the article was first published.
@@ -284,23 +284,23 @@ yet are broadly used and agreed upon.
 * `article:tag` - [string](#string) [array](#array) -
   Tag words associated with this article.
 
-<a name="type_book" href="#type_book">`book`</a> - Namespace URI: [`http://ogp.me/ns/book#`](http://ogp.me/ns/book)
+<a name="type_book" href="#type_book">`book`</a> - Namespace URI: [`https://ogp.me/ns/book#`](https://ogp.me/ns/book)
 
 * `book:author` - [profile](#type_profile) [array](#array) - Who wrote this book.
 * `book:isbn` - [string](#string) -
-  The [ISBN](http://en.wikipedia.org/wiki/International_Standard_Book_Number)
+  The [ISBN](https://en.wikipedia.org/wiki/International_Standard_Book_Number)
 * `book:release_date` - [datetime](#datetime) - The date the book was released.
 * `book:tag` - [string](#string) [array](#array) -
   Tag words associated with this book.
 
-<a name="type_profile" href="#type_profile">`profile`</a> - Namespace URI: [`http://ogp.me/ns/profile#`](http://ogp.me/ns/profile)
+<a name="type_profile" href="#type_profile">`profile`</a> - Namespace URI: [`https://ogp.me/ns/profile#`](https://ogp.me/ns/profile)
 
 * `profile:first_name` - [string](#string) - A name normally given to an individual by a parent or self-chosen.
 * `profile:last_name` - [string](#string) - A name inherited from a family or marriage and by which the individual is commonly known.
 * `profile:username` - [string](#string) - A short unique string to identify them.
 * `profile:gender` - [enum](#enum)(male, female) - Their gender.
 
-<a name="type_website" href="#type_website">`website`</a> - Namespace URI: [`http://ogp.me/ns/website#`](http://ogp.me/ns/website)
+<a name="type_website" href="#type_website">`website`</a> - Namespace URI: [`https://ogp.me/ns/website#`](https://ogp.me/ns/website)
 
 No additional properties other than the basic ones.
 Any non-marked up webpage should be treated as `og:type` website.
@@ -329,7 +329,7 @@ The following types are used when defining attributes in Open Graph protocol.
   <td><a name="datetime" href="#datetime">DateTime</td>
   <td>A DateTime represents a temporal value composed of a date
     (year, month, day) and an optional time component (hours, minutes)</td>
-  <td><a href="http://en.wikipedia.org/wiki/ISO_8601">ISO 8601</a></td>
+  <td><a href="https://en.wikipedia.org/wiki/ISO_8601">ISO 8601</a></td>
 </tr>
 
 <tr>
@@ -380,16 +380,15 @@ The following types are used when defining attributes in Open Graph protocol.
 The open source community has developed a number of parsers and publishing
 tools. Let the Facebook group know if you've built something awesome too!
 
-* [Facebook Object Debugger](http://developers.facebook.com/tools/debug/) - Facebook's official parser and debugger.
-* [Google Rich Snippets Testing Tool](http://www.google.com/webmasters/tools/richsnippets) - Open Graph protocol support in specific verticals and Search Engines.
+* [Facebook Object Debugger](https://developers.facebook.com/tools/debug/) - Facebook's official parser and debugger.
+* [Google Rich Snippets Testing Tool](https://www.google.com/webmasters/tools/richsnippets) - Open Graph protocol support in specific verticals and Search Engines.
 * [PHP Validator and Markup Generator](https://github.com/niallkennedy/open-graph-protocol-tools) - OGP 2011 input validator and markup generator in PHP5 objects.
-* [PHP Consumer](http://github.com/scottmac/opengraph) - A small library for accessing of Open Graph Protocol data in PHP.
-* [OpenGraphNode in PHP](http://buzzword.org.uk/2010/opengraph/#php) - A simple parser for PHP.
-* [PyOpenGraph](http://pypi.python.org/pypi/PyOpenGraph) - A library written in Python for parsing Open Graph protocol information from web sites.
-* [OpenGraph Ruby](http://github.com/intridea/opengraph) - Ruby Gem which parses web pages and extracts Open Graph protocol markup.
-* [OpenGraph for Java](http://github.com/callumj/opengraph-java) - Small Java class used to represent the Open Graph protocol.
-* [RDF::RDFa::Parser](http://search.cpan.org/~tobyink/RDF-RDFa-Parser/lib/RDF/RDFa/Parser.pm) - Perl RDFa parser which understands the Open Graph protocol.
-* [Alternate WordPress OGP plugin](http://wordpress.org/plugins/wp-facebook-open-graph-protocol/) - A simple lightweight WordPress plugin which adds Open Graph metadata to WordPress powered sites.
+* [PHP Consumer](https://github.com/scottmac/opengraph) - A small library for accessing of Open Graph Protocol data in PHP.
+* [OpenGraphNode in PHP](https://buzzword.org.uk/2010/opengraph/#php) - A simple parser for PHP.
+* [PyOpenGraph](https://pypi.python.org/pypi/PyOpenGraph) - A library written in Python for parsing Open Graph protocol information from web sites.
+* [OpenGraph Ruby](https://github.com/intridea/opengraph) - Ruby Gem which parses web pages and extracts Open Graph protocol markup.
+* [OpenGraph for Java](https://github.com/callumj/opengraph-java) - Small Java class used to represent the Open Graph protocol.
+* [RDF::RDFa::Parser](https://search.cpan.org/~tobyink/RDF-RDFa-Parser/lib/RDF/RDFa/Parser.pm) - Perl RDFa parser which understands the Open Graph protocol.
 
 
 ---

--- a/index.html
+++ b/index.html
@@ -26,24 +26,30 @@
       <img alt="Open Graph protocol logo" src="https://ogp.me/logo.png" width="300" height="300">
     </div>
     <div id="content">
-<h2 id="aidintrohrefintrointroductiona"><a id="intro" href="#intro">Introduction</a></h2>
+      <h2><a id="intro" href="#intro">Introduction</a></h2>
+
 <p>The <a href="https://ogp.me/">Open Graph protocol</a> enables any web page to become a
 rich object in a social graph. For instance, this is used on Facebook to allow
 any web page to have the same functionality as any other object on Facebook.</p>
+
 <p>While many different technologies and schemas exist and could be combined
 together, there isn't a single technology which provides enough information to
 richly represent any web page within the social graph. The Open Graph protocol
 builds on these existing technologies and gives developers one thing to
 implement. Developer simplicity is a key goal of the Open Graph protocol which
-has informed many of <a href="https://www.scribd.com/doc/30715288/The-Open-Graph-Protocol-Design-Decisions">the technical design decisions</a>.
-</p>
+has informed many of
+<a href="https://www.scribd.com/doc/30715288/The-Open-Graph-Protocol-Design-Decisions">the technical design decisions</a>.</p>
+
 <hr />
-<h2 id="aidmetadatahrefmetadatabasicmetadataa"><a id="metadata" href="#metadata">Basic Metadata</a></h2>
+
+<h2><a id="metadata" href="#metadata">Basic Metadata</a></h2>
+
 <p>To turn your web pages into graph objects, you need to add basic metadata to
 your page. We've based the initial version of the protocol on
 <a href="https://en.wikipedia.org/wiki/RDFa">RDFa</a> which means that you'll place
 additional <code>&lt;meta&gt;</code> tags in the <code>&lt;head&gt;</code> of your web page. The four required
 properties for every page are:</p>
+
 <ul>
 <li><code>og:title</code> - The title of your object as it should appear within the graph,
 e.g., "The Rock".</li>
@@ -54,8 +60,10 @@ graph.</li>
 <li><code>og:url</code> - The canonical URL of your object that will be used as its
 permanent ID in the graph, e.g., "https://www.imdb.com/title/tt0117500/".</li>
 </ul>
+
 <p>As an example, the following is the Open Graph protocol markup for <a href="https://www.imdb.com/title/tt0117500/">The Rock on
 IMDB</a>:</p>
+
 <pre><code>&lt;html prefix="og: https://ogp.me/ns#"&gt;
 &lt;head&gt;
 &lt;title&gt;The Rock (1996)&lt;/title&gt;
@@ -68,15 +76,18 @@ IMDB</a>:</p>
 ...
 &lt;/html&gt;
 </code></pre>
-<h3 id="aidoptionalhrefoptionaloptionalmetadataa"><a id="optional" href="#optional">Optional Metadata</a></h3>
+
+<h3><a id="optional" href="#optional">Optional Metadata</a></h3>
+
 <p>The following properties are optional for any object and are generally
 recommended:</p>
+
 <ul>
 <li><code>og:audio</code> - A URL to an audio file to accompany this object.</li>
 <li><code>og:description</code> - A one to two sentence description of your object.</li>
 <li><code>og:determiner</code> - The word that appears before this object's title
 in a sentence. An <a href="#enum">enum</a> of (a, an, the, "", auto). If <code>auto</code> is 
-chosen, the consumer of your data should chose between "a" or "an".
+chosen, the consumer of your data should choose between "a" or "an".
 Default is "" (blank).</li>
 <li><code>og:locale</code> - The locale these tags are marked up in.
 Of the format <code>language_TERRITORY</code>. Default is <code>en_US</code>.</li>
@@ -86,7 +97,9 @@ available in.</li>
 should be displayed for the overall site. e.g., "IMDb".</li>
 <li><code>og:video</code> - A URL to a video file that complements this object.</li>
 </ul>
+
 <p>For example (line-break solely for display purposes):</p>
+
 <pre><code>&lt;meta property="og:audio" content="https://example.com/bond/theme.mp3" /&gt;
 &lt;meta property="og:description" 
   content="Sean Connery found fame and fortune as the
@@ -98,14 +111,20 @@ should be displayed for the overall site. e.g., "IMDb".</li>
 &lt;meta property="og:site_name" content="IMDb" /&gt;
 &lt;meta property="og:video" content="https://example.com/bond/trailer.swf" /&gt;
 </code></pre>
+
 <p>The RDF schema (in <a href="https://en.wikipedia.org/wiki/Turtle_(syntax)">Turtle</a>) 
 can be found at <a href="https://ogp.me/ns/ogp.me.ttl">ogp.me/ns</a>.</p>
+
 <hr />
-<h2 id="aidstructuredhrefstructuredstructuredpropertiesa"><a id="structured" href="#structured">Structured Properties</a></h2>
+
+<h2><a id="structured" href="#structured">Structured Properties</a></h2>
+
 <p>Some properties can have extra metadata attached to them.
 These are specified in the same way as other metadata with <code>property</code> and
 <code>content</code>, but the <code>property</code> will have extra <code>:</code>.</p>
+
 <p>The <code>og:image</code> property has some optional structured properties:</p>
+
 <ul>
 <li><code>og:image:url</code> - Identical to <code>og:image</code>.</li>
 <li><code>og:image:secure_url</code> - An alternate url to use if the webpage requires
@@ -115,39 +134,52 @@ HTTPS.</li>
 <li><code>og:image:height</code> - The number of pixels high.</li>
 <li><code>og:image:alt</code> - A description of what is in the image (not a caption). If the page specifies an og:image it should specify <code>og:image:alt</code>.</li>
 </ul>
+
 <p>A full image example:</p>
-<pre><code>&lt;meta property="og:image" content="https://example.com/ogp.jpg" /&gt;
+
+<pre><code>&lt;meta property="og:image" content="http://example.com/ogp.jpg" /&gt;
 &lt;meta property="og:image:secure_url" content="https://secure.example.com/ogp.jpg" /&gt;
 &lt;meta property="og:image:type" content="image/jpeg" /&gt;
 &lt;meta property="og:image:width" content="400" /&gt;
 &lt;meta property="og:image:height" content="300" /&gt;
 &lt;meta property="og:image:alt" content="A shiny red apple with a bite taken out" /&gt;
 </code></pre>
+
 <p>The <code>og:video</code> tag has the identical tags as <code>og:image</code>. Here is an example:</p>
-<pre><code>&lt;meta property="og:video" content="https://example.com/movie.swf" /&gt;
+
+<pre><code>&lt;meta property="og:video" content="http://example.com/movie.swf" /&gt;
 &lt;meta property="og:video:secure_url" content="https://secure.example.com/movie.swf" /&gt;
 &lt;meta property="og:video:type" content="application/x-shockwave-flash" /&gt;
 &lt;meta property="og:video:width" content="400" /&gt;
 &lt;meta property="og:video:height" content="300" /&gt;
 </code></pre>
+
 <p>The <code>og:audio</code> tag only has the first 3 properties available
 (since size doesn't make sense for sound):</p>
-<pre><code>&lt;meta property="og:audio" content="https://example.com/sound.mp3" /&gt;
+
+<pre><code>&lt;meta property="og:audio" content="http://example.com/sound.mp3" /&gt;
 &lt;meta property="og:audio:secure_url" content="https://secure.example.com/sound.mp3" /&gt;
 &lt;meta property="og:audio:type" content="audio/mpeg" /&gt;
 </code></pre>
+
 <hr />
-<h2 id="aidarrayhrefarrayarraysa"><a id="array" href="#array">Arrays</a></h2>
+
+<h2><a id="array" href="#array">Arrays</a></h2>
+
 <p>If a tag can have multiple values, just put multiple versions of the same
 <code>&lt;meta&gt;</code> tag on your page. The first tag (from top to bottom) is given
 preference during conflicts.</p>
+
 <pre><code>&lt;meta property="og:image" content="https://example.com/rock.jpg" /&gt;
 &lt;meta property="og:image" content="https://example.com/rock2.jpg" /&gt;
 </code></pre>
+
 <p>Put structured properties after you declare their root tag. Whenever
 another root element is parsed, that structured property
 is considered to be done and another one is started.</p>
+
 <p>For example:</p>
+
 <pre><code>&lt;meta property="og:image" content="https://example.com/rock.jpg" /&gt;
 &lt;meta property="og:image:width" content="300" /&gt;
 &lt;meta property="og:image:height" content="300" /&gt;
@@ -155,31 +187,44 @@ is considered to be done and another one is started.</p>
 &lt;meta property="og:image" content="https://example.com/rock3.jpg" /&gt;
 &lt;meta property="og:image:height" content="1000" /&gt;
 </code></pre>
+
 <p>means there are 3 images on this page, the first image is <code>300x300</code>, the middle
 one has unspecified dimensions, and the last one is <code>1000</code>px tall.</p>
+
 <hr />
-<h2 id="aidtypeshreftypesobjecttypesa"><a id="types" href="#types">Object Types</a></h2>
+
+<h2><a id="types" href="#types">Object Types</a></h2>
+
 <p>In order for your object to be represented within the graph, you need to
 specify its type. This is done using the <code>og:type</code> property:</p>
+
 <pre><code>&lt;meta property="og:type" content="website" /&gt;
 </code></pre>
+
 <p>When the community agrees on the schema for a type, it is added to the list
 of global types. All other objects in the type system are
 <a href="https://en.wikipedia.org/wiki/CURIE">CURIEs</a> of the form</p>
+
 <pre><code>&lt;head prefix="my_namespace: https://example.com/ns#"&gt;
 &lt;meta property="og:type" content="my_namespace:my_type" /&gt;
 </code></pre>
+
 <p>The global types are grouped into verticals. Each vertical has its
 own namespace. The <code>og:type</code> values for a namespace are always prefixed with
 the namespace and then a period.
 This is to reduce confusion with user-defined namespaced types which always
 have colons in them.</p>
-<h3 id="aidtype_musichreftype_musicmusica"><a id="type_music" href="#type_music">Music</a></h3>
+
+<h3><a id="type_music" href="#type_music">Music</a></h3>
+
 <ul>
 <li>Namespace URI: <a href="https://ogp.me/ns/music"><code>https://ogp.me/ns/music#</code></a></li>
 </ul>
+
 <p><code>og:type</code> values:</p>
+
 <p><a name="type_music.song" href="#type_music.song"><code>music.song</code></a></p>
+
 <ul>
 <li><code>music:duration</code> - <a href="#integer">integer</a> &gt;=1 - The song's length in seconds.</li>
 <li><code>music:album</code> - <a href="#type_music.album">music.album</a> <a href="#array">array</a> -
@@ -191,7 +236,9 @@ Which track this song is.</li>
 <li><code>music:musician</code> - <a href="#type_profile">profile</a> <a href="#array">array</a> -
 The musician that made this song.</li>
 </ul>
+
 <p><a name="type_music.album" href="#type_music.album"><code>music.album</code></a></p>
+
 <ul>
 <li><code>music:song</code> - <a href="#type_music.song">music.song</a> - The song on this album.</li>
 <li><code>music:song:disc</code> - <a href="#integer">integer</a> &gt;=1 -
@@ -203,23 +250,32 @@ The musician that made this song.</li>
 <li><code>music:release_date</code> - <a href="#datetime">datetime</a> - 
 The date the album was released.</li>
 </ul>
+
 <p><a name="type_music.playlist" href="#type_music.playlist"><code>music.playlist</code></a></p>
+
 <ul>
 <li><code>music:song</code> - Identical to the ones on <a href="#type_music.album">music.album</a></li>
 <li><code>music:song:disc</code></li>
 <li><code>music:song:track</code></li>
 <li><code>music:creator</code> - <a href="#type_profile">profile</a> - The creator of this playlist.</li>
 </ul>
+
 <p><a name="type_music.radio_station" href="#type_music.radio_station"><code>music.radio_station</code></a></p>
+
 <ul>
 <li><code>music:creator</code> - <a href="#type_profile">profile</a> - The creator of this station.</li>
 </ul>
-<h3 id="aidtype_videohreftype_videovideoa"><a id="type_video" href="#type_video">Video</a></h3>
+
+<h3><a id="type_video" href="#type_video">Video</a></h3>
+
 <ul>
 <li>Namespace URI: <a href="https://ogp.me/ns/video"><code>https://ogp.me/ns/video#</code></a></li>
 </ul>
+
 <p><code>og:type</code> values:</p>
+
 <p><a name="type_video.movie" href="#type_video.movie"><code>video.movie</code></a></p>
+
 <ul>
 <li><code>video:actor</code> - <a href="#type_profile">profile</a> <a href="#array">array</a> -
 Actors in the movie.</li>
@@ -235,7 +291,9 @@ The date the movie was released.</li>
 <li><code>video:tag</code> - <a href="#string">string</a> <a href="#array">array</a> -
 Tag words associated with this movie.</li>
 </ul>
+
 <p><a name="type_video.episode" href="#type_video.episode"><code>video.episode</code></a></p>
+
 <ul>
 <li><code>video:actor</code> - Identical to <a href="#type_video.movie">video.movie</a></li>
 <li><code>video:actor:role</code></li>
@@ -247,17 +305,26 @@ Tag words associated with this movie.</li>
 <li><code>video:series</code> - <a href="#type_video.tv_show">video.tv_show</a> -
 Which series this episode belongs to.</li>
 </ul>
+
 <p><a name="type_video.tv_show" href="#type_video.tv_show"><code>video.tv_show</code></a></p>
+
 <p>A multi-episode TV show.
 The metadata is identical to <a href="#type_video.movie">video.movie</a>.</p>
+
 <p><a name="type_video.other" href="#type_video.other"><code>video.other</code></a></p>
+
 <p>A video that doesn't belong in any other category.
 The metadata is identical to <a href="#type_video.movie">video.movie</a>.</p>
-<h3 id="aidno_verticalhrefno_verticalnoverticala"><a id="no_vertical" href="#no_vertical">No Vertical</a></h3>
+
+<h3><a id="no_vertical" href="#no_vertical">No Vertical</a></h3>
+
 <p>These are globally defined objects that just don't fit into a vertical but
 yet are broadly used and agreed upon.</p>
+
 <p><code>og:type</code> values:</p>
+
 <p><a name="type_article" href="#type_article"><code>article</code></a> - Namespace URI: <a href="https://ogp.me/ns/article"><code>https://ogp.me/ns/article#</code></a></p>
+
 <ul>
 <li><code>article:published_time</code> - <a href="#datetime">datetime</a> - 
 When the article was first published.</li>
@@ -271,7 +338,9 @@ Writers of the article.</li>
 <li><code>article:tag</code> - <a href="#string">string</a> <a href="#array">array</a> -
 Tag words associated with this article.</li>
 </ul>
+
 <p><a name="type_book" href="#type_book"><code>book</code></a> - Namespace URI: <a href="https://ogp.me/ns/book"><code>https://ogp.me/ns/book#</code></a></p>
+
 <ul>
 <li><code>book:author</code> - <a href="#type_profile">profile</a> <a href="#array">array</a> - Who wrote this book.</li>
 <li><code>book:isbn</code> - <a href="#string">string</a> -
@@ -280,19 +349,27 @@ The <a href="https://en.wikipedia.org/wiki/International_Standard_Book_Number">I
 <li><code>book:tag</code> - <a href="#string">string</a> <a href="#array">array</a> -
 Tag words associated with this book.</li>
 </ul>
+
 <p><a name="type_profile" href="#type_profile"><code>profile</code></a> - Namespace URI: <a href="https://ogp.me/ns/profile"><code>https://ogp.me/ns/profile#</code></a></p>
+
 <ul>
 <li><code>profile:first_name</code> - <a href="#string">string</a> - A name normally given to an individual by a parent or self-chosen.</li>
 <li><code>profile:last_name</code> - <a href="#string">string</a> - A name inherited from a family or marriage and by which the individual is commonly known.</li>
 <li><code>profile:username</code> - <a href="#string">string</a> - A short unique string to identify them.</li>
 <li><code>profile:gender</code> - <a href="#enum">enum</a>(male, female) - Their gender.</li>
 </ul>
+
 <p><a name="type_website" href="#type_website"><code>website</code></a> - Namespace URI: <a href="https://ogp.me/ns/website"><code>https://ogp.me/ns/website#</code></a></p>
+
 <p>No additional properties other than the basic ones.
 Any non-marked up webpage should be treated as <code>og:type</code> website.</p>
+
 <hr />
-<h2 id="aiddata_typeshrefdata_typestypesa"><a id="data_types" href="#data_types">Types</a></h2>
+
+<h2><a id="data_types" href="#data_types">Types</a></h2>
+
 <p>The following types are used when defining attributes in Open Graph protocol.</p>
+
 <table>
 <tr>
   <th width=150><b>Type</b></th>
@@ -351,42 +428,36 @@ Any non-marked up webpage should be treated as <code>og:type</code> website.</p>
 <tr>
   <td><a name="url" href="#url">URL</td>
   <td>A sequence of Unicode characters that identify an Internet resource.
-  <td>All valid URLs that utilize the https:// or https:// protocols</td>
+  <td>All valid URLs that utilize the http:// or https:// protocols</td>
 </tr>
 
 </table>
+
 <hr />
-<h2 id="aidimplementationshrefimplementationsimplementationsa"><a id='implementations' href="#implementations">Implementations</a></h2>
+
+<h2><a id='implementations' href="#implementations">Implementations</a></h2>
+
 <p>The open source community has developed a number of parsers and publishing
 tools. Let the Facebook group know if you've built something awesome too!</p>
+
 <ul>
-<li><a href="https://developers.facebook.com/tools/debug/">Facebook Object Debugger</a> -
-Facebook's official parser and debugger</li>
+<li><a href="https://developers.facebook.com/tools/debug/">Facebook Object Debugger</a> - Facebook's official parser and debugger.</li>
 <li><a href="https://www.google.com/webmasters/tools/richsnippets">Google Rich Snippets Testing Tool</a> - Open Graph protocol support in specific verticals and Search Engines.</li>
-<li><a href="https://github.com/niallkennedy/open-graph-protocol-tools">PHP Validator and Markup Generator</a> -  OGP 2011 input validator and markup generator in PHP5 objects</li>
-<li><a href="https://github.com/scottmac/opengraph">PHP Consumer</a> -
-a small library for accessing of Open Graph Protocol data in PHP</li>
-<li><a href="https://buzzword.org.uk/2010/opengraph/#php">OpenGraphNode in PHP</a> -
-a simple parser for PHP</li>
-<li><a href="https://pypi.python.org/pypi/PyOpenGraph">PyOpenGraph</a> -
-a library written in Python for parsing Open Graph protocol
-information from web sites</li>
-<li><a href="https://github.com/intridea/opengraph">OpenGraph Ruby</a> -
-Ruby Gem which parses web pages and extracts Open Graph protocol markup</li>
-<li><a href="https://github.com/callumj/opengraph-java">OpenGraph for Java</a> -
-small Java class used to represent the Open Graph protocol</li>
-<li><a href="https://search.cpan.org/~tobyink/RDF-RDFa-Parser/lib/RDF/RDFa/Parser.pm">RDF::RDFa::Parser</a> -
-Perl RDFa parser which understands the Open Graph protocol</li>
-<li><a href="https://wordpress.org/plugins/facebook/">WordPress plugin</a> -
-Facebook's official WordPress plugin, which adds Open Graph metadata to WordPress powered sites. </li>
-<li><a href="https://wordpress.org/plugins/wp-facebook-open-graph-protocol/">Alternate WordPress OGP plugin</a> -
-A simple lightweight WordPress plugin which adds Open Graph metadata to WordPress powered sites. </li>
+<li><a href="https://github.com/niallkennedy/open-graph-protocol-tools">PHP Validator and Markup Generator</a> - OGP 2011 input validator and markup generator in PHP5 objects.</li>
+<li><a href="https://github.com/scottmac/opengraph">PHP Consumer</a> - A small library for accessing of Open Graph Protocol data in PHP.</li>
+<li><a href="https://buzzword.org.uk/2010/opengraph/#php">OpenGraphNode in PHP</a> - A simple parser for PHP.</li>
+<li><a href="https://pypi.python.org/pypi/PyOpenGraph">PyOpenGraph</a> - A library written in Python for parsing Open Graph protocol information from web sites.</li>
+<li><a href="https://github.com/intridea/opengraph">OpenGraph Ruby</a> - Ruby Gem which parses web pages and extracts Open Graph protocol markup.</li>
+<li><a href="https://github.com/callumj/opengraph-java">OpenGraph for Java</a> - Small Java class used to represent the Open Graph protocol.</li>
+<li><a href="https://search.cpan.org/~tobyink/RDF-RDFa-Parser/lib/RDF/RDFa/Parser.pm">RDF::RDFa::Parser</a> - Perl RDFa parser which understands the Open Graph protocol.</li>
 </ul>
+
+<hr />
     </div>
     <div id="footer">
       <p>The Open Graph protocol was originally created at Facebook and is inspired by <a href="https://en.wikipedia.org/wiki/Dublin_Core">Dublin Core</a>, <a href="https://googlewebmastercentral.blogspot.com/2009/02/specify-your-canonical.html">link-rel canonical</a>, <a href="https://microformats.org/">Microformats</a>, and <a href="https://en.wikipedia.org/wiki/RDFa">RDFa</a>. The specification described on this page is available under the <a href="https://openwebfoundation.org/legal/the-0-9-agreements---necessary-claims">Open Web Foundation Agreement, Version 0.9</a>. This website is <a href="https://github.com/facebook/open-graph-protocol">Open Source</a>. </p>
     </div>
     </div>
-</script>
+
   </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -6,7 +6,7 @@
  * For instance, this is used on Facebook to allow any web page to have the same functionality
  * as any other object on Facebook.
  *
- * Visit http://ogp.me/.
+ * Visit https://ogp.me/.
  *
  * @author Facebook team & GitHub contributors (see https://github.com/facebook/open-graph-protocol/graphs/contributors)
  */
@@ -28,7 +28,7 @@ $html = Markdown::defaultTransform($markdown);
 ?>
 <!DOCTYPE html>
 <html>
-  <head prefix="og: http://ogp.me/ns#">
+  <head prefix="og: https://ogp.me/ns#">
     <meta charset="utf-8">
     <title>The Open Graph protocol</title>
     <meta name="description" content="The Open Graph protocol enables any web page to become a rich object in a social graph.">
@@ -36,48 +36,30 @@ $html = Markdown::defaultTransform($markdown);
     <link rel="stylesheet" href="base.css" type="text/css">
     <meta property="og:title" content="Open Graph protocol">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="http://ogp.me/">
-    <meta property="og:image" content="http://ogp.me/logo.png">
+    <meta property="og:url" content="https://ogp.me/">
+    <meta property="og:image" content="https://ogp.me/logo.png">
     <meta property="og:image:type" content="image/png">
     <meta property="og:image:width" content="300">
     <meta property="og:image:height" content="300">
+    <meta property="og:image:alt" content="The Open Graph logo">
     <meta property="og:description" content="The Open Graph protocol enables any web page to become a rich object in a social graph.">
-    <meta prefix="fb:http://ogp.me/ns/fb#" property="fb:app_id" content="115190258555800">
-    <link rel="alternate" type="application/rdf+xml" href="http://ogp.me/ns/ogp.me.rdf">
-    <link rel="alternate" type="text/turtle" href="http://ogp.me/ns/ogp.me.ttl">
+    <meta prefix="fb: https://ogp.me/ns/fb#" property="fb:app_id" content="115190258555800">
+    <link rel="alternate" type="application/rdf+xml" href="https://ogp.me/ns/ogp.me.rdf">
+    <link rel="alternate" type="text/turtle" href="https://ogp.me/ns/ogp.me.ttl">
   </head>
   <body>
     <div id="body">
     <div id="header">
       <h1>The Open Graph protocol</h1>
-      <img alt="Open Graph protocol logo" src="http://ogp.me/logo.png" width="300" height="300">
+      <img alt="Open Graph protocol logo" src="https://ogp.me/logo.png" width="300" height="300">
     </div>
     <div id="content">
       <?php echo $html; ?>
     </div>
     <div id="footer">
-      <iframe src="//www.facebook.com/plugins/like.php?href=http%3A%2F%2Fogp.me%2F&send=false&layout=standard&width=450&show_faces=true&action=like&colorscheme=light&height=80&appId=115190258555800" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:450px; height:80px;" allowTransparency="true"></iframe>
-      <p>The Open Graph protocol was originally created at Facebook and is inspired by <a href="http://en.wikipedia.org/wiki/Dublin_Core">Dublin Core</a>, <a href="http://googlewebmastercentral.blogspot.com/2009/02/specify-your-canonical.html">link-rel canonical</a>, <a href="http://microformats.org/">Microformats</a>, and <a href="http://en.wikipedia.org/wiki/RDFa">RDFa</a>. The specification described on this page is available under the <a href="http://openwebfoundation.org/legal/the-0-9-agreements---necessary-claims">Open Web Foundation Agreement, Version 0.9</a>. This website is <a href="https://github.com/facebook/open-graph-protocol">Open Source</a>. Last updated <?php $updated_time = filemtime( $base_dir . '/content/index.markdown' ); ?><time pubdate="<?php echo date('c', $updated_time); ?>"><?php date_default_timezone_set('UTC'); echo date( 'F dS, Y', $updated_time ); ?></time></p>
+      <p>The Open Graph protocol was originally created at Facebook and is inspired by <a href="https://en.wikipedia.org/wiki/Dublin_Core">Dublin Core</a>, <a href="https://googlewebmastercentral.blogspot.com/2009/02/specify-your-canonical.html">link-rel canonical</a>, <a href="https://microformats.org/">Microformats</a>, and <a href="https://en.wikipedia.org/wiki/RDFa">RDFa</a>. The specification described on this page is available under the <a href="https://openwebfoundation.org/legal/the-0-9-agreements---necessary-claims">Open Web Foundation Agreement, Version 0.9</a>. This website is <a href="https://github.com/facebook/open-graph-protocol">Open Source</a>. </p>
     </div>
     </div>
-<script type="text/javascript">
-var _sf_async_config={uid:1415,domain:"ogp.me"};
-(function(){
-  function loadChartbeat() {
-    window._sf_endpt=(new Date()).getTime();
-    var e = document.createElement('script');
-    e.setAttribute('language', 'javascript');
-    e.setAttribute('type', 'text/javascript');
-    e.setAttribute('src',
-       (("https:" == document.location.protocol) ? "https://s3.amazonaws.com/" : "http://") +
-       "static.chartbeat.com/js/chartbeat.js");
-    document.body.appendChild(e);
-  }
-  var oldonload = window.onload;
-  window.onload = (typeof window.onload != 'function') ?
-     loadChartbeat : function() { oldonload(); loadChartbeat(); };
-})();
 
-</script>
   </body>
 </html>

--- a/ns/ogp.me.rdf
+++ b/ns/ogp.me.rdf
@@ -63,6 +63,12 @@
     <rdfs:isDefinedBy rdf:resource="http://ogp.me/ns#" />
     <rdfs:range rdf:resource="http://ogp.me/ns/class#integer_str" />
   </rdf:Property>
+  <rdf:Property rdf:about="http://ogp.me/ns#image:alt">
+    <rdfs:label xml:lang="en-US">image alternative text</rdfs:label>
+    <rdfs:comment xml:lang="en-US">A description of what is in the image.</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="http://ogp.me/ns#" />
+    <rdfs:range rdf:resource="http://ogp.me/ns/class#string" />
+  </rdf:Property>
   <rdf:Property rdf:about="http://ogp.me/ns#video">
     <rdfs:label xml:lang="en-US">video</rdfs:label>
     <rdfs:comment xml:lang="en-US">A relevant video URL for your object.</rdfs:comment>

--- a/ns/ogp.me.ttl
+++ b/ns/ogp.me.ttl
@@ -65,6 +65,11 @@ og:image a rdf:Property ;
   rdfs:comment "The height of an image."@en-US ;
   rdfs:isDefinedBy og: ;
   rdfs:range ogc:integer_str .
+<http://ogp.me/ns#image:alt> a rdf:Property ;
+  rdfs:label "image alternative text"@en-US ;
+  rdfs:comment "A description of what is in the image."@en-US ;
+  rdfs:isDefinedBy og: ;
+  rdfs:range ogc:string .
 og:video a rdf:Property ;
   rdfs:label "video"@en-US ;
   rdfs:comment "A relevant video URL for your object."@en-US ;


### PR DESCRIPTION
- `og:image:alt` is not currently in the markdown source, nor is it in the schemas (not that we serve those properly anyway)
- The HTML we're serving isn't in sync with the markdown/php source. Update all 3 to bring them in sync so we can have reproducible builds (`php index.php >| index.html`). Note that the generated HTML has minimal content changes. Mostly whitespace or headers not getting generated ids (which aren't useful anyway given we have anchors with ids). Wordpress plugin references were removed since those are long dead.