### PR TITLE
Use datatype string for profile:gender property

### DIFF
--- a/content/index.markdown
+++ b/content/index.markdown
@@ -308,7 +308,7 @@ yet are broadly used and agreed upon.
 * `profile:first_name` - [string](#string) - A name normally given to an individual by a parent or self-chosen.
 * `profile:last_name` - [string](#string) - A name inherited from a family or marriage and by which the individual is commonly known.
 * `profile:username` - [string](#string) - A short unique string to identify them.
-* `profile:gender` - [enum](#enum)(male, female) - Their gender.
+* `profile:gender` - [string](#string) - A string describing their gender.
 
 <a name="type_website" href="#type_website">`website`</a> - Namespace URI: [`https://ogp.me/ns/website#`](https://ogp.me/ns/website)
 

--- a/index.html
+++ b/index.html
@@ -368,7 +368,7 @@ Tag words associated with this book.</li>
 <li><code>profile:first_name</code> - <a href="#string">string</a> - A name normally given to an individual by a parent or self-chosen.</li>
 <li><code>profile:last_name</code> - <a href="#string">string</a> - A name inherited from a family or marriage and by which the individual is commonly known.</li>
 <li><code>profile:username</code> - <a href="#string">string</a> - A short unique string to identify them.</li>
-<li><code>profile:gender</code> - <a href="#enum">enum</a>(male, female) - Their gender.</li>
+<li><code>profile:gender</code> - <a href="#string">string</a> - A string describing their gender.</li>
 </ul>
 
 <p><a name="type_website" href="#type_website"><code>website</code></a> - Namespace URI: <a href="https://ogp.me/ns/website"><code>https://ogp.me/ns/website#</code></a></p>


### PR DESCRIPTION
Change the datatype for the profile:gender property to string. Previously, the datatype was enum(male, female), which made it effectively impossible to encode genders other than male or female.

In the EU, you are required by law (Article 16 GDPR, Right to rectification) to correct incorrect information. Due to the standard, it was either not permitted to encode gender in some jurisdictions (e.g., Germany), where more genders than male or female are legally recognized, or you needed to ignore the standard.

The decision to use a string, instead of expanding the enum to include more gender descriptions, was based on the fact that different jurisdictions legally recognize different genders. To keep the standard simple, this implementation was chosen. Also, not explicitly mentioning non-binary genders will make this change less prone to attacks from TERFs, Trump supporters, or other assholes.

This is, first and foremost, a political commit. Any technical content you encounter is a byproduct of political acts and should be considered as such.